### PR TITLE
Change yaml.load to yaml.safe_load

### DIFF
--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -85,7 +85,7 @@ def get_module_info():
 
     module_dir = os.path.join("/", *dir_path)
     with open("module.yml") as m:
-        module_name = yaml.load(m)["name"]
+        module_name = yaml.safe_load(m)["name"]
 
     return module_dir, module_name
 


### PR DESCRIPTION
This removes a warning about yaml.load when using this pytest plugin. I don't think the extra functionality that yaml.load offers over yaml.safe_load is necessary to load the module.yml fille.