### PR TITLE
Multiple repo paths

### DIFF
--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -1,0 +1,20 @@
+"""
+    Copyright 2020 Inmanta
+    Contact: code@inmanta.com
+    License: Apache 2.0
+"""
+from os import path
+
+from inmanta import module
+
+
+def test_multiple_paths(project):
+    project_inmanta = module.Project(project._test_project_dir)
+    module_repo_urls = [repo.baseurl for repo in project_inmanta.externalResolver.children]
+    assert 'https://github.com/inmanta2/' in module_repo_urls
+    assert 'https://github.com/inmanta/' in module_repo_urls
+    with open(path.join(project._test_project_dir, "project.yml"), "r") as project_file:
+        content = project_file.read()
+        assert "repo: ['https://github.com/inmanta2/', 'https://github.com/inmanta/']" in content
+
+

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -63,8 +63,9 @@ def pytest_addoption(parser):
         'inmanta', 'inmanta module testing plugin')
     group.addoption('--venv', dest='inm_venv',
                     help='folder in which to place the virtual env for tests (will be shared by all tests), overrides INMANTA_TEST_ENV')
-    group.addoption('--module_repo', dest='inm_module_repo',
-                    help='location to download modules from, overrides INMANTA_MODULE_REPO')
+    group.addoption('--module_repo', dest='inm_module_repo', action="append",
+                    help='location to download modules from, overrides INMANTA_MODULE_REPO.'
+                         'Can be specified multiple times to add multiple locations')
     group.addoption('--install_mode', dest='inm_install_mode',
                     help='Install mode for modules downloaded during this test',
                     choices=module.INSTALL_OPTS)
@@ -124,7 +125,13 @@ def project_shared(request):
     test_project_dir = tempfile.mkdtemp()
     os.mkdir(os.path.join(test_project_dir, "libs"))
 
-    repos = get_opt_or_env_or(request.config, "inm_module_repo", "https://github.com/inmanta/").split(" ")
+    repo_options = get_opt_or_env_or(request.config, "inm_module_repo", "https://github.com/inmanta/")
+    repos = []
+    if isinstance(repo_options, list):
+        for repo in repo_options:
+            repos += repo.split(" ")
+    else:
+        repos = repo_options.split(" ")
 
     install_mode = get_opt_or_env_or(request.config, "inm_install_mode", "release")        
 

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -107,6 +107,18 @@ def test_multiple_repo_paths_option(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_multiple_repo_paths_multiple_options(testdir):
+    testdir.copy_example("testmodule")
+
+    result = testdir.runpytest(
+        "tests/test_multiple_repo_paths.py",
+        "--module_repo",
+        "https://github.com/inmanta2/",
+        "--module_repo",
+        "https://github.com/inmanta/"
+    )
+    result.assert_outcomes(passed=1)
+
 def test_multiple_repo_paths_env(testdir, monkeypatch):
     monkeypatch.setenv("INMANTA_MODULE_REPO", "https://github.com/inmanta2/ https://github.com/inmanta/")
     testdir.copy_example("testmodule")

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -94,4 +94,22 @@ def test_release_mode_validation(testdir):
 
     result = testdir.runpytest("tests/test_resource_run.py", "--install_mode", "other")
     assert "error: argument --install_mode: invalid choice: 'other' (choose from 'master', 'prerelease', 'release')" in "\n".join(result.errlines)
-    
+
+
+def test_multiple_repo_paths_option(testdir):
+    testdir.copy_example("testmodule")
+
+    result = testdir.runpytest(
+        "tests/test_resource_run.py",
+        "--module_repo",
+        "https://github.com/inmanta2/ https://github.com/inmanta/"
+    )
+    result.assert_outcomes(passed=1)
+
+
+def test_multiple_repo_paths_env(testdir, monkeypatch):
+    monkeypatch.setenv("INMANTA_MODULE_REPO", "https://github.com/inmanta2/ https://github.com/inmanta/")
+    testdir.copy_example("testmodule")
+
+    result = testdir.runpytest("tests/test_resource_run.py")
+    result.assert_outcomes(passed=1)

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -100,7 +100,7 @@ def test_multiple_repo_paths_option(testdir):
     testdir.copy_example("testmodule")
 
     result = testdir.runpytest(
-        "tests/test_resource_run.py",
+        "tests/test_multiple_repo_paths.py",
         "--module_repo",
         "https://github.com/inmanta2/ https://github.com/inmanta/"
     )
@@ -111,5 +111,5 @@ def test_multiple_repo_paths_env(testdir, monkeypatch):
     monkeypatch.setenv("INMANTA_MODULE_REPO", "https://github.com/inmanta2/ https://github.com/inmanta/")
     testdir.copy_example("testmodule")
 
-    result = testdir.runpytest("tests/test_resource_run.py")
+    result = testdir.runpytest("tests/test_multiple_repo_paths.py")
     result.assert_outcomes(passed=1)


### PR DESCRIPTION
Closes #38 
Specifying multiple repo paths is already possible, if they are separated by spaces.
Or should the separator be changed to comma?