### PR TITLE
project.compile logs the model with line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.6.0 (?)
 Changes in this release:
 - Added the ability to assert the expected 'change' of a deploy
+- Compiled models are logged (debug level), with line numbers (#199)
 
 # v 1.5.0 (2021-03-26)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -621,7 +621,7 @@ license: Test License
         module.Project.set(test_project)
         test_project.load()
 
-    def compile(self, main: str, export: bool = False, no_dedent: bool = False):
+    def compile(self, main: str, export: bool = False, no_dedent: bool = False) -> None:
         """
         Compile the configuration model in main. This method will load all required modules.
 

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -19,6 +19,7 @@ import glob
 import importlib
 import json
 import logging
+import math
 import os
 import shutil
 import sys
@@ -26,7 +27,6 @@ import tempfile
 import warnings
 from collections import defaultdict
 from distutils import dir_util
-from math import floor, log
 from pathlib import Path
 from textwrap import dedent
 from types import FunctionType, ModuleType
@@ -639,7 +639,7 @@ license: Test License
         # logging model with line numbers
         def enumerate_model(model: str):
             lines = model.split("\n")
-            leading_zeros = floor(log(len(lines), 10)) + 1
+            leading_zeros = math.floor(math.log(len(lines), 10)) + 1
             line_numbers_model = "\n".join(
                 [
                     f"{str(number).zfill(leading_zeros)}    {line}"

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -625,9 +625,9 @@ license: Test License
         """
         Compile the configuration model in main. This method will load all required modules.
 
-        :attr main: The model to compile
-        :attr main: Whether the model should be exported after the compile
-        :attr no_dedent: Don't remove additional indentation in the model
+        :param main: The model to compile
+        :param export: Whether the model should be exported after the compile
+        :param no_dedent: Don't remove additional indentation in the model
         """
         # Dedent the input format
         model = dedent(main.strip("\n")) if not no_dedent else main


### PR DESCRIPTION
# Description

Unless specified otherwise (`no_dedent` parameter), the model provided to `project.compile` will be un-indented (we remove any space of tab at the beginning of lines if they are common to all the lines).

Before compiling the model, we log it (debug level), with line numbers.  (Makes it easier to debug error messages containing line numbers.)

closes #199 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
