### PR TITLE
Set no_dedent argument of project.compile() to True by default

### DIFF
--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -621,7 +621,7 @@ license: Test License
         module.Project.set(test_project)
         test_project.load()
 
-    def compile(self, main: str, export: bool = False, no_dedent: bool = False) -> None:
+    def compile(self, main: str, export: bool = False, no_dedent: bool = True) -> None:
         """
         Compile the configuration model in main. This method will load all required modules.
 


### PR DESCRIPTION
# Description

Set `no_dedent` argument of `project.compile()` to `True` by default to maintain backwards compatibility with `pytest-inmanta` version 1.5.2.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
