### PR TITLE
fixed ResourceIdStr import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 1.7.0 (?)
 Changes in this release:
 
+# v 1.6.1 (2021-06-29)
+Changes in this release:
+- Fixed an invalid import from inmanta-core (inmanta-core#3074)
+
 # v 1.6.0 (2021-06-18)
 Changes in this release:
 - Added the ability to assert the expected 'change' of a deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes in this release:
 
 # v 1.6.1 (2021-06-29)
 Changes in this release:
-- Fixed an invalid import from inmanta-core (inmanta-core#3074)
+- Fixed an invalid import from inmanta-core (inmanta/inmanta-core#3074)
 
 # v 1.6.0 (2021-06-18)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -42,7 +42,8 @@ from inmanta import compiler, config, const, module, protocol
 from inmanta.agent import cache, handler
 from inmanta.agent import io as agent_io
 from inmanta.agent.handler import HandlerContext, ResourceHandler
-from inmanta.data import LogLine, ResourceIdStr
+from inmanta.data import LogLine
+from inmanta.data.model import ResourceIdStr
 from inmanta.data.model import AttributeStateChange
 from inmanta.execute.proxy import DynamicProxy
 from inmanta.export import Exporter, ResourceDict, cfg_env

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -43,8 +43,7 @@ from inmanta.agent import cache, handler
 from inmanta.agent import io as agent_io
 from inmanta.agent.handler import HandlerContext, ResourceHandler
 from inmanta.data import LogLine
-from inmanta.data.model import ResourceIdStr
-from inmanta.data.model import AttributeStateChange
+from inmanta.data.model import AttributeStateChange, ResourceIdStr
 from inmanta.execute.proxy import DynamicProxy
 from inmanta.export import Exporter, ResourceDict, cfg_env
 from inmanta.protocol import json_encode


### PR DESCRIPTION
# Description

Fixed ResourceIdStr import: this was previously imported from `inmanta.data` while it actually lives in `inmanta.data.model`.

I'm planning to do a patch release after merging.

closes inmanta/inmanta-core#3074

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
