### PR TITLE
fixed test case making use of inmanta.module.Project internals

### DIFF
--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -5,14 +5,17 @@
 """
 from os import path
 
-from inmanta import module
+from inmanta import module, ModuleRepo
 
 
 def test_multiple_paths(project):
     project_inmanta = module.Project(project._test_project_dir)
-    module_repo_urls = [
-        repo.baseurl for repo in project_inmanta.module_source_v1.remote_repo.children
-    ]
+    children: List[ModuleRepo] = (
+        project_inmanta.module_source_v1.remote_repo.children
+        if hasattr(project_inmanta, "module_source_v1")
+        else project_inmanta.externalResolver.children
+    )
+    module_repo_urls = [repo.baseurl for repo in children]
     assert "https://github.com/inmanta2/" in module_repo_urls
     assert "https://github.com/inmanta/" in module_repo_urls
     with open(path.join(project._test_project_dir, "project.yml"), "r") as project_file:

--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -5,12 +5,12 @@
 """
 from os import path
 
-from inmanta import module, ModuleRepo
+from inmanta import module
 
 
 def test_multiple_paths(project):
     project_inmanta = module.Project(project._test_project_dir)
-    children: List[ModuleRepo] = (
+    children: List[module.ModuleRepo] = (
         project_inmanta.module_source_v1.remote_repo.children
         if hasattr(project_inmanta, "module_source_v1")
         else project_inmanta.externalResolver.children

--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -13,7 +13,9 @@ def test_multiple_paths(project):
     project_inmanta = module.Project(project._test_project_dir)
     children: List[module.ModuleRepo] = (
         project_inmanta.module_source_v1.remote_repo.children
+        # latest inmanta-core
         if hasattr(project_inmanta, "module_source_v1")
+        # backwards compatibility with ISO3 and ISO4
         else project_inmanta.externalResolver.children
     )
     module_repo_urls = [repo.baseurl for repo in children]

--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -4,6 +4,7 @@
     License: Apache 2.0
 """
 from os import path
+from typing import List
 
 from inmanta import module
 

--- a/examples/testmodule/tests/test_multiple_repo_paths.py
+++ b/examples/testmodule/tests/test_multiple_repo_paths.py
@@ -11,7 +11,7 @@ from inmanta import module
 def test_multiple_paths(project):
     project_inmanta = module.Project(project._test_project_dir)
     module_repo_urls = [
-        repo.baseurl for repo in project_inmanta.externalResolver.children
+        repo.baseurl for repo in project_inmanta.module_source_v1.remote_repo.children
     ]
     assert "https://github.com/inmanta2/" in module_repo_urls
     assert "https://github.com/inmanta/" in module_repo_urls


### PR DESCRIPTION
This test case made use of the internals of `Project`. It started failing after I merged inmanta/inmanta-core#3166 yesterday.
The new changes are not typed correctly in the same way the old ones weren't due to the way the `ModuleRepo` classes and methods are typed.