### PR TITLE
Add support to test pytest-inmanta against all ISO branches

### DIFF
--- a/Jenkinsfile-integration-tests-iso3
+++ b/Jenkinsfile-integration-tests-iso3
@@ -50,16 +50,6 @@
             }
           }
         }
-
-        stage("code linting") {
-          steps{
-            dir(env.REPO_NAME) {
-              sh'''
-                ${WORKSPACE}/env/bin/flake8 examples pytest_inmanta tests
-              '''
-            }
-          }
-        }
     }
 
     post {

--- a/Jenkinsfile-integration-tests-iso3
+++ b/Jenkinsfile-integration-tests-iso3
@@ -26,6 +26,7 @@
           steps {
             deleteDir()
             dir(env.REPO_NAME) {
+              checkout scm
               script {
                 sh '''
                   rm -rf ${WORKSPACE}/env

--- a/Jenkinsfile-integration-tests-iso3
+++ b/Jenkinsfile-integration-tests-iso3
@@ -1,0 +1,69 @@
+/*
+ * Test the pytest-inmanta version used by the ISO3 product (pytest-inmanta<1.5.0) against
+ * the corresponding inmanta-core version.
+ */
+ pipeline {
+    agent any
+    triggers {
+        cron(BRANCH_NAME == "master" ? "H H(2-5) * * *": "")
+     }
+
+    environment {
+        REPO_NAME="pytest-inmanta"
+        PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
+        PIP_PRE="true"
+    }
+
+    options {
+        disableConcurrentBuilds()
+        checkoutToSubdirectory(env.REPO_NAME)
+        skipDefaultCheckout()
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+    }
+
+    stages {
+        stage("Setup") {
+          steps {
+            deleteDir()
+            dir(env.REPO_NAME) {
+              script {
+                sh '''
+                  rm -rf ${WORKSPACE}/env
+                  python3 -m venv ${WORKSPACE}/env
+                  ${WORKSPACE}/env/bin/python3 -m pip install -U setuptools pip
+
+                  # Versions used by ISO3
+                  ${WORKSPACE}/env/bin/python3 -m pip install -U "pytest-inmanta<1.5.0" "inmanta~=2020.4.7"
+                '''
+              }
+            }
+          }
+        }
+
+        stage("Run tests") {
+          steps {
+            dir(env.REPO_NAME) {
+              sh '''
+                ${WORKSPACE}/env/bin/python3 -m pytest --junitxml=junit.xml --log-cli-level DEBUG -s -vvv tests --basetemp=${WORKSPACE}/tmp
+              '''
+            }
+          }
+        }
+
+        stage("code linting") {
+          steps{
+            dir(env.REPO_NAME) {
+              sh'''
+                ${WORKSPACE}/env/bin/flake8 examples pytest_inmanta tests
+              '''
+            }
+          }
+        }
+    }
+
+    post {
+      always {
+        junit "${env.REPO_NAME}/junit.xml"
+      }
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36-inm{master,iso4,iso3}
+envlist = pep8,py36-inm{master,iso4}
 skip_missing_interpreters=True
 requires =
     pip >= 21.0.1
@@ -13,7 +13,6 @@ deps=
     -rrequirements.txt
     inmmaster: git+https://github.com/inmanta/inmanta-core.git@master
     inmiso4: git+https://github.com/inmanta/inmanta-core.git@iso4
-    inmiso3: git+https://github.com/inmanta/inmanta-core.git@iso3
 commands=py.test --junitxml=junit.xml --log-cli-level DEBUG -s -vvv tests/
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT INMANTA_MODULE_REPO PIP_INDEX_URL PIP_PRE
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@ basepython=python3.6
 [testenv]
 deps=
     -rrequirements.txt
-    inmmaster: git+https://github.com/inmanta/inmanta-core.git@master
-    inmiso4: git+https://github.com/inmanta/inmanta-core.git@iso4
+    inmiso4: inmanta-core~=4.0.dev
 commands=py.test --junitxml=junit.xml --log-cli-level DEBUG -s -vvv tests/
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT INMANTA_MODULE_REPO PIP_INDEX_URL PIP_PRE
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = pep8,py36-inm{master,iso4,iso3}
+skip_missing_interpreters=True
+requires =
+    pip >= 21.0.1
+    setuptools
+
+[testenv:py36]
+basepython=python3.6
+
+[testenv]
+deps=
+    -rrequirements.txt
+    inmmaster: git+https://github.com/inmanta/inmanta-core.git@master
+    inmiso4: git+https://github.com/inmanta/inmanta-core.git@iso4
+    inmiso3: git+https://github.com/inmanta/inmanta-core.git@iso3
+commands=py.test --junitxml=junit.xml --log-cli-level DEBUG -s -vvv tests/
+passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT INMANTA_MODULE_REPO PIP_INDEX_URL PIP_PRE
+
+[testenv:pep8]
+commands = flake8 examples pytest_inmanta tests
+basepython = python3


### PR DESCRIPTION
# Description

* Add tox configuration to run the tests against ISO4 and master
* Add separate pipeline to run the tests against pytest-inmanta version used by the ISO3 product. 

closes inmanta/inmanta-core#3214

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
- [x] Code is clear and sufficiently documented
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
