### PR TITLE
Issue/fix kwargs typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.7.0 (?)
 Changes in this release:
 - Ensure that projects are compiled using a separate venv.
+- Fixed typing issue for filter_args in different method of the Project class.
 
 # v 1.6.2 (2021-08-17)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -275,7 +275,7 @@ install_mode: %(install_mode)s
             module_dir, os.path.join(test_project_dir, "libs", module_name)
         )
 
-    def create_project(**kwargs):
+    def create_project(**kwargs: object):
         extended_kwargs: typing.Dict[str, object] = {
             "load_plugins": not get_opt_or_env_or(
                 request.config, "inm_no_load_plugins", False
@@ -530,7 +530,7 @@ class Project:
         json_encode({"message": ctx.logs})
 
     def get_resource(
-        self, resource_type: str, **filter_args: typing.Dict[str, object]
+        self, resource_type: str, **filter_args: object
     ) -> typing.Optional[Resource]:
         """
         Get a resource of the given type and given filter on the resource attributes. If multiple resource match, the
@@ -589,7 +589,7 @@ class Project:
         status: const.ResourceState = const.ResourceState.deployed,
         run_as_root: bool = False,
         change: const.Change = None,
-        **filter_args: typing.Dict[str, object],
+        **filter_args: object,
     ) -> Resource:
         """
         Deploy a resource of the given type, that matches the filter and assert the outcome
@@ -633,7 +633,7 @@ class Project:
         resource_type: str,
         status: const.ResourceState = const.ResourceState.dry,
         run_as_root: bool = False,
-        **filter_args: typing.Dict[str, object],
+        **filter_args: object,
     ) -> typing.Dict[str, AttributeStateChange]:
         """
         Run a dryrun for a specific resource.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(os.path.join(cwd, "README.md"), encoding="utf-8") as fd:
 
 setup(
     name="pytest-inmanta",
-    version="1.7.0",
+    version="1.7.1",
     description=(
         "A py.test plugin providing fixtures to simplify inmanta modules testing."
     ),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(os.path.join(cwd, "README.md"), encoding="utf-8") as fd:
 
 setup(
     name="pytest-inmanta",
-    version="1.7.1",
+    version="1.7.0",
     description=(
         "A py.test plugin providing fixtures to simplify inmanta modules testing."
     ),


### PR DESCRIPTION
# Description

 - The typing hints were a bit off in a few methods of the Project class.  The `**filter_args` parameters where hinted as `Dict[str, object]` while it seems it should be `object`.  
 - Minor version bump: I was not 100% sure about that, as a change in the type hints, even if it is a fix, can be a breaking change for any repo using mypy in its ci.  Though, I believe that if any ci uses this module and makes a type check, either it doesn't use these methods, or they had to patch this type (probably with `type: ignore` which then wouldn't cause issue).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
