### PR TITLE
always allow dev install for inmanta-core master in tox config file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ basepython=python3.6
 [testenv]
 deps=
     -rrequirements.txt
+    inmmaster: inmanta-core>=0.0.dev
     inmiso4: inmanta-core~=4.0.dev
 commands=py.test --junitxml=junit.xml --log-cli-level DEBUG -s -vvv tests/
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT INMANTA_MODULE_REPO PIP_INDEX_URL PIP_PRE


### PR DESCRIPTION
Suggestion: always allow dev installs for `inmanta-core` for the `py36-inmmaster` environment. Currently this is only allowed when `PIP_PRE` is set. The pipelines on Jenkins do set it, so it doesn't cause any issues at the moment, except when running locally without setting `PIP_PRE`.