### PR TITLE
Issue/248 module state reset

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 2.0.0
 tag = False
 commit = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-# v 1.7.0 (?)
+# v 2.0.0 (?)
 Changes in this release:
 - Added support for testing v2 modules.
+- Extended to be compatible with `inmanta-core>=6`
+- Added support for custom `inmanta_reset_state` method to clean up stateful modules between compiles
 - Ensure that projects are compiled using a separate venv.
 - Fixed typing issue for `filter_args` in different method of the Project class.
+
+## Breaking changes
+- pytest-inmanta now keeps `inmanta_plugins` submodules alive accross compiles. As a result, stateful modules must implement
+    custom state cleanup logic as described in the README.
 
 # v 1.6.2 (2021-08-17)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes in this release:
 - Fixed typing issue for `filter_args` in different method of the Project class.
 
 ## Breaking changes
-- pytest-inmanta now keeps `inmanta_plugins` submodules alive accross compiles. As a result, stateful modules must implement
+- pytest-inmanta now keeps `inmanta_plugins` submodules alive across compiles. As a result, stateful modules must implement
     custom state cleanup logic as described in the README.
 
 # v 1.6.2 (2021-08-17)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ A test case, to test this plugin looks like this:
   function named `plugin_name`. As such, this line tests whether `host` is returned when the plugin function
   `hostname` is called with the parameter `fqdn`.
 
+## Advanced usage
+
+Because pytest-inmanta keeps `inmanta_plugins` submodule objects alive to support top-level imports, any stateful modules
+(modules that keep state on global Python variables in the module's namespace) must define cleanup logic to reset state between
+compiles. Pytest-inmanta expects such cleanup functions to be synchronous functions that live in the top-level scope (defined
+on the module object, not in a class) of a `inmanta_plugins` submodule (of any depth). Their name should start with
+"inmanta\_reset\_state" and they should not take any parameters. For example:
+
+```python
+    # <module-name>/plugins/state.py
+
+    MY_STATE = set()
+
+    def inmanta_reset_state() -> None:
+        global MY_STATE
+        MY_STATE = set()
+```
+
+Multiple cleanup functions may be defined, in which case no guaranteed call order is defined.
+
 ## Options
 
 The following options are available.

--- a/examples/testmodule/plugins/__init__.py
+++ b/examples/testmodule/plugins/__init__.py
@@ -75,3 +75,11 @@ def get_exception():
 @plugin
 def raise_exception():
     raise TestException("my exception")
+
+
+MODULE_CACHE = set()
+
+
+def inmanta_reset_state() -> None:
+    global MODULE_CACHE
+    MODULE_CACHE = set()

--- a/examples/testmodule/plugins/submod.py
+++ b/examples/testmodule/plugins/submod.py
@@ -5,3 +5,17 @@
 """
 
 submod_loaded: bool = True
+
+
+MODULE_CACHE_ONE = set()
+MODULE_CACHE_TWO = set()
+
+
+def inmanta_reset_state_one() -> None:
+    global MODULE_CACHE_ONE
+    MODULE_CACHE_ONE = set()
+
+
+def inmanta_reset_state_two() -> None:
+    global MODULE_CACHE_TWO
+    MODULE_CACHE_TWO = set()

--- a/examples/testmodule/tests/test_state.py
+++ b/examples/testmodule/tests/test_state.py
@@ -1,0 +1,37 @@
+"""
+    Copyright 2021 Inmanta
+    Contact: code@inmanta.com
+    License: Apache 2.0
+"""
+
+
+def test_module_state(project, inmanta_plugins) -> None:
+    """
+    Verify that state on Python module objects does not carry accross compiles if an appropriate cleanup hook is defined.
+    """
+    assert len(inmanta_plugins.testmodule.MODULE_CACHE) == 0
+    inmanta_plugins.testmodule.MODULE_CACHE.add(1)
+    assert 1 in inmanta_plugins.testmodule.MODULE_CACHE
+
+    project.compile("import testmodule")
+
+    assert len(inmanta_plugins.testmodule.MODULE_CACHE) == 0
+
+
+def test_module_state_advanced(project, inmanta_plugins) -> None:
+    """
+    Verify that
+        - cleanup hooks on submodules get called as well
+        - if more than one cleanup hook is defined, all are called
+    """
+    assert len(inmanta_plugins.testmodule.submod.MODULE_CACHE_ONE) == 0
+    assert len(inmanta_plugins.testmodule.submod.MODULE_CACHE_TWO) == 0
+    inmanta_plugins.testmodule.submod.MODULE_CACHE_ONE.add(1)
+    inmanta_plugins.testmodule.submod.MODULE_CACHE_TWO.add(2)
+    assert 1 in inmanta_plugins.testmodule.submod.MODULE_CACHE_ONE
+    assert 2 in inmanta_plugins.testmodule.submod.MODULE_CACHE_TWO
+
+    project.compile("import testmodule")
+
+    assert len(inmanta_plugins.testmodule.submod.MODULE_CACHE_ONE) == 0
+    assert len(inmanta_plugins.testmodule.submod.MODULE_CACHE_TWO) == 0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(os.path.join(cwd, "README.md"), encoding="utf-8") as fd:
 
 setup(
     name="pytest-inmanta",
-    version="1.7.0",
+    version="2.0.0",
     description=(
         "A py.test plugin providing fixtures to simplify inmanta modules testing."
     ),

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -155,3 +155,13 @@ def test_project_no_plugins(testdir):
         "DeprecationWarning: The project_no_plugins fixture is deprecated"
         " in favor of the INMANTA_TEST_NO_LOAD_PLUGINS environment variable."
     ) in result.stdout.str()
+
+
+def test_import(testdir):
+    """Make sure that importing functions works."""
+
+    testdir.copy_example("testmodule")
+
+    result = testdir.runpytest("tests/test_state.py")
+
+    result.assert_outcomes(passed=2)

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -157,7 +157,7 @@ def test_project_no_plugins(testdir):
     ) in result.stdout.str()
 
 
-def test_import(testdir):
+def test_state(testdir):
     """Make sure that importing functions works."""
 
     testdir.copy_example("testmodule")


### PR DESCRIPTION
# Description

Adds support for custom `inmanta_reset_state` method to clean up stateful modules between compiles

Also bumped the version because #248 illustrates a breaking changes was introduced.

@bartv I'm including you not necessarily for the implementation but for the approach, the name of the function and the clarity of the documentation.

closes #248

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
