### PR TITLE
Fix bug where the project fixture doesn't reset the CWD in cleanup stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 2.1.0 (?)
 Changes in this release:
+- Fix bug where the `project` fixture doesn't reset the current working directory in the cleanup stage.
 
 # v 2.0.0 (2022-01-24)
 Changes in this release:

--- a/examples/testmodule/tests/test_cwd.py
+++ b/examples/testmodule/tests/test_cwd.py
@@ -1,0 +1,26 @@
+"""
+    Copyright 2022 Inmanta
+    Contact: code@inmanta.com
+    License: Apache 2.0
+"""
+import os
+
+CURDIR = os.getcwd()
+test_case_one_ran = False
+
+
+def test_case_one(project) -> None:
+    """
+    Verify that the project fixture has changed the CWD.
+    """
+    global test_case_one_ran
+    test_case_one_ran = True
+    assert os.getcwd() != CURDIR
+
+
+def test_case_two() -> None:
+    """
+    Verify that project fixture resets the CWD in the cleanup stage.
+    """
+    assert test_case_one_ran, "test_case_one should execute fore test_case_two"
+    assert os.getcwd() == CURDIR

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1026,6 +1026,7 @@ license: Test License
             initpy=get_module_data("init.py"),
         )
         ProjectLoader.clear_dynamic_modules()
+        os.chdir(CURDIR)
 
     def finalize_handler(self, handler: ResourceHandler) -> None:
         handler.cache.close()

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -165,3 +165,13 @@ def test_state(testdir):
     result = testdir.runpytest("tests/test_state.py")
 
     result.assert_outcomes(passed=2)
+
+
+def test_cwd(testdir):
+    """Ensure that the project fixture resets the cwd after each test case."""
+
+    testdir.copy_example("testmodule")
+
+    result = testdir.runpytest("tests/test_cwd.py")
+
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
# Description

This PR fixes the bug where the `project` fixture doesn't reset the CWD in the cleanup stage. This bug makes the `git clone` invocation fail that is required to checkout V1 modules.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
