### PR TITLE
[FEAT] Make sure sys.executable points to the same python interpretor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# v 2.2.0 (?)
+# v 2.1.1 (?)
 Changes in this release:
+- The `project` fixture now makes `sys.executable` point to the compiler's executable
+
 
 # v 2.1.0 (2022-03-30)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 2.1.1 (?)
+# v 2.2.0 (?)
 Changes in this release:
 - The `project` fixture now makes `sys.executable` point to the compiler's executable
 

--- a/examples/testhandler/tests/test_handler.py
+++ b/examples/testhandler/tests/test_handler.py
@@ -142,7 +142,7 @@ def test_close_cache(project):
     assert len(handler.cache.cache) == 0
 
 
-def test_sys_executable(project):
+def test_280_sys_executable(project):
     """
     Make sure the current python interpreter is the same as the one used by the compiler
     """

--- a/examples/testhandler/tests/test_handler.py
+++ b/examples/testhandler/tests/test_handler.py
@@ -15,6 +15,9 @@
 
     Contact: code@inmanta.com
 """
+import sys
+from pathlib import Path
+
 import pytest
 
 from inmanta import const
@@ -137,3 +140,10 @@ def test_close_cache(project):
     versions = handler.cache.counterforVersion.keys()
     assert len(versions) == 0
     assert len(handler.cache.cache) == 0
+
+
+def test_sys_executable(project):
+    """
+    Make sure the current python interpreter is the same as the one used by the compiler
+    """
+    assert Path(project._env_path) == Path(sys.executable).parent.parent

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -170,7 +170,6 @@ def project(
     DATA.clear()
     project_shared.clean()
     project_shared.init(capsys)
-    project_shared.synchronize_interpreters()
     yield project_shared
     project_shared.clean()
 
@@ -188,7 +187,6 @@ def project_no_plugins(
     DATA.clear()
     project_shared_no_plugins.clean()
     project_shared_no_plugins.init(capsys)
-    project_shared_no_plugins.synchronize_interpreters()
     yield project_shared_no_plugins
     project_shared_no_plugins.clean()
 
@@ -662,7 +660,7 @@ class Project:
         self._handlers: typing.Set[ResourceHandler] = set()
         config.Config.load_config()
 
-    def synchronize_interpreters(self) -> None:
+    def _synchronize_interpreters(self) -> None:
         """
         Store the python interpreter used by the compiler in sys.executable
         """
@@ -688,6 +686,7 @@ class Project:
         self.ctx = None
         self._handlers = set()
         self._load()
+        self._synchronize_interpreters()
         config.Config.load_config()
 
     def _create_project_and_load(self, model: str) -> module.Project:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -660,7 +660,7 @@ class Project:
         self._handlers: typing.Set[ResourceHandler] = set()
         config.Config.load_config()
 
-    def _synchronize_interpreters(self) -> None:
+    def _set_sys_executable(self) -> None:
         """
         Store the python interpreter used by the compiler in sys.executable
         """
@@ -686,7 +686,7 @@ class Project:
         self.ctx = None
         self._handlers = set()
         self._load()
-        self._synchronize_interpreters()
+        self._set_sys_executable()
         config.Config.load_config()
 
     def _create_project_and_load(self, model: str) -> module.Project:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -188,7 +188,7 @@ def project_no_plugins(
     DATA.clear()
     project_shared_no_plugins.clean()
     project_shared_no_plugins.init(capsys)
-    project_shared.synchronize_interpreters()
+    project_shared_no_plugins.synchronize_interpreters()
     yield project_shared_no_plugins
     project_shared_no_plugins.clean()
 

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -169,8 +169,11 @@ def project(
     DATA.clear()
     project_shared.clean()
     project_shared.init(capsys)
+    stashed_path = sys.executable
+    sys.executable = project_shared.get_compiler_executable()
     yield project_shared
     project_shared.clean()
+    sys.executable = stashed_path
 
 
 @pytest.fixture()
@@ -658,6 +661,12 @@ class Project:
         self.ctx: typing.Optional[HandlerContext] = None
         self._handlers: typing.Set[ResourceHandler] = set()
         config.Config.load_config()
+
+    def get_compiler_executable(self) -> str:
+        if sys.platform != "win32":
+            return os.path.join(self._env_path, "bin", "python")
+        else:
+            return os.path.join(self._env_path, "Scripts", "python.exe")
 
     def init(self, capsys: CaptureFixture) -> None:
         self._stdout = None

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -22,7 +22,7 @@ def test_resource(testdir):
 
     result = testdir.runpytest("tests/test_handler.py")
 
-    result.assert_outcomes(passed=5)
+    result.assert_outcomes(passed=6)
 
 
 def test_dryrun(testdir):


### PR DESCRIPTION
… as the one used by the compiler

# Description

Override the `sys.executable` variable with the path to the python interpreter used by the compiler.

closes #280 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
