### PR TITLE
Issue/set pytest option default to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 2.4.0 (?)
 Changes in this release:
 
+# v 2.3.1 (2022-05-16)
+Changes in this release:
+ - Fixed test parameter framework for boolean options.
+
 # v 2.3.0 (2022-05-13)
 Changes in this release:
 - Added test parameter framework (#288).

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -93,6 +93,11 @@ def pytest_addoption(parser: "Parser") -> None:
             kwargs: Dict[str, object] = dict(
                 action=param.action,
                 help=param.help,
+                # We overwrite the default here, to ensure that even boolean options don't default to the opposite of
+                # the store action.  If we don't do this, config.getoption will always return a value, either True or
+                # False depending on the action and whether the flag is set or not, this makes it impossible to use
+                # environment variables for the option.
+                default=None,
             )
             if param.choices is not None:
                 kwargs["choices"] = param.choices


### PR DESCRIPTION
# Description

Fix bug for boolean option in parameter framework.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
