### PR TITLE
Issue/support late parameter registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 2.4.0 (?)
 Changes in this release:
 
+# v 2.3.2 (2022-05-17)
+Changes in this release:
+ - Allow other plugins to register test parameters after pytest has loaded pytest-inmanta plugin.
+
 # v 2.3.1 (2022-05-16)
 Changes in this release:
  - Fixed test parameter framework for boolean options.

--- a/pytest_inmanta/parameters.py
+++ b/pytest_inmanta/parameters.py
@@ -73,14 +73,13 @@ inm_mod_repo_legacy = ListTestParameter(
         "Location to download modules from."
         "Can be specified multiple times to add multiple locations"
     ),
-    default=["https://github.com/inmanta/"],
 )
 
 inm_mod_repo = ListTestParameter(
     argument="--module-repo",
     environment_variable=inm_mod_repo_legacy.environment_variable,
     usage=inm_mod_repo_legacy.usage,
-    default=inm_mod_repo_legacy.default,
+    default=["https://github.com/inmanta/"],
     group=param_group,
     legacy=inm_mod_repo_legacy,
 )
@@ -93,7 +92,6 @@ inm_install_mode_legacy = EnumTestParameter(
     environment_variable="INMANTA_INSTALL_MODE",
     usage="Install mode for modules downloaded during this test",
     enum=InstallMode,
-    default=InstallMode.release,
 )
 
 inm_install_mode = EnumTestParameter(
@@ -101,7 +99,7 @@ inm_install_mode = EnumTestParameter(
     environment_variable=inm_install_mode_legacy.environment_variable,
     usage=inm_install_mode_legacy.usage,
     enum=inm_install_mode_legacy.enum,
-    default=inm_install_mode_legacy.default,
+    default=InstallMode.release,
     group=param_group,
     legacy=inm_install_mode_legacy,
 )

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -34,7 +34,7 @@ from itertools import chain
 from pathlib import Path
 from textwrap import dedent
 from types import FunctionType, ModuleType
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 import pydantic
 import pytest
@@ -72,7 +72,7 @@ try:
     Those classes are only used in type annotation, but the import doesn't work
     in python 3.6.  So we simply catch the error and ignore it.
     """
-    from pytest import CaptureFixture, OptionGroup, Parser
+    from pytest import CaptureFixture, Parser
 except ImportError:
     pass
 
@@ -82,27 +82,7 @@ SYS_EXECUTABLE = sys.executable
 
 
 def pytest_addoption(parser: "Parser") -> None:
-    for group_name, parameters in TestParameterRegistry.test_parameter_groups().items():
-        group: Union["Parser", "OptionGroup"]
-        if group_name is None:
-            group = parser
-        else:
-            group = parser.getgroup(group_name)
-
-        for param in parameters:
-            kwargs: Dict[str, object] = dict(
-                action=param.action,
-                help=param.help,
-                # We overwrite the default here, to ensure that even boolean options don't default to the opposite of
-                # the store action.  If we don't do this, config.getoption will always return a value, either True or
-                # False depending on the action and whether the flag is set or not, this makes it impossible to use
-                # environment variables for the option.
-                default=None,
-            )
-            if param.choices is not None:
-                kwargs["choices"] = param.choices
-
-            group.addoption(param.argument, **kwargs)
+    TestParameterRegistry.pytest_addoption(parser)
 
 
 def get_module() -> typing.Tuple[module.Module, str]:

--- a/pytest_inmanta/test_parameter/parameter.py
+++ b/pytest_inmanta/test_parameter/parameter.py
@@ -154,7 +154,8 @@ class TestParameterRegistry:
         registered.
         """
         if cls.__parser is not None:
-            raise RuntimeError("Options can not be registered more than once")
+            # Options can not be registered more than once
+            return
 
         # Saving the parser for late option registration
         cls.__parser = parser

--- a/pytest_inmanta/test_parameter/parameter.py
+++ b/pytest_inmanta/test_parameter/parameter.py
@@ -20,14 +20,14 @@ import os
 import uuid
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Container, Dict, Generic, List, Optional, Set, TypeVar
+from typing import Container, Dict, Generic, List, Optional, Set, TypeVar, Union
 
 try:
     """
     Those classes are only used in type annotation, but the import doesn't work
     in python 3.6.  So we simply catch the error and ignore it.
     """
-    from pytest import Config
+    from pytest import Config, OptionGroup, Parser
 except ImportError:
     pass
 
@@ -65,6 +65,39 @@ class TestParameterRegistry:
     __test_parameter_groups: Dict[Optional[str], Set["TestParameter"]] = defaultdict(
         set
     )
+    __parser: Optional["Parser"] = None
+
+    @staticmethod
+    def add_option(
+        parser: "Parser", group_name: Optional[str], test_parameter: "TestParameter"
+    ) -> None:
+        """
+        This static method adds the option defined in test_parameter to the parser provided in argument.
+        If group_name is not None, the option will be added to the group named :param group_name:.
+
+        :param parser: The parser to register the option in
+        :param group_name: The name of the group the option is a part of
+        :param test_parameter: The test parameter holding all the option's information
+        """
+        group: Union["Parser", "OptionGroup"]
+        if group_name is None:
+            group = parser
+        else:
+            group = parser.getgroup(group_name)
+
+        kwargs: Dict[str, object] = dict(
+            action=test_parameter.action,
+            help=test_parameter.help,
+            # We overwrite the default here, to ensure that even boolean options don't default to the opposite of
+            # the store action.  If we don't do this, config.getoption will always return a value, either True or
+            # False depending on the action and whether the flag is set or not, this makes it impossible to use
+            # environment variables for the option.
+            default=None,
+        )
+        if test_parameter.choices is not None:
+            kwargs["choices"] = test_parameter.choices
+
+        group.addoption(test_parameter.argument, **kwargs)
 
     @classmethod
     def register(
@@ -73,17 +106,34 @@ class TestParameterRegistry:
         test_parameter: "TestParameter",
         group: Optional[str] = None,
     ) -> None:
+        """
+        Register a parameter, you should not call this method your self.
+        This method is called by the constructor of TestParameter.
+        """
         if key is None:
             key = str(uuid.uuid4())
+
         cls.__test_parameters[key] = test_parameter
         cls.__test_parameter_groups[group].add(test_parameter)
 
+        if cls.__parser is not None:
+            # Pytest has already loaded this plugin, we need to add the option now
+            TestParameterRegistry.add_option(cls.__parser, group, test_parameter)
+
     @classmethod
     def test_parameters(cls) -> List["TestParameter"]:
+        """
+        Get all the registered parameters
+        """
         return sorted(cls.__test_parameters.values(), key=lambda param: param.argument)
 
     @classmethod
     def test_parameter_groups(cls) -> Dict[Optional[str], List["TestParameter"]]:
+        """
+        Get all the registered parameters, grouped by group name.  The output is a dict holding
+        for each group name (key) the list of all parameters (value).  The parameters which are
+        not part of a group are grouped in a list at key None.
+        """
         return {
             group: sorted(parameters, key=lambda param: param.argument)
             for group, parameters in cls.__test_parameter_groups.items()
@@ -91,7 +141,28 @@ class TestParameterRegistry:
 
     @classmethod
     def test_parameter(cls, key: str) -> "TestParameter":
+        """
+        Get the parameter that was created with key :param key:, if it is not found, raise a KeyError
+        """
         return cls.__test_parameters[key]
+
+    @classmethod
+    def pytest_addoption(cls, parser: "Parser") -> None:
+        """
+        This method should be called once (and only once) in pytest_inmanta.plugin.pytest_addoption
+        It will register the parser for later use and setup all the options that have already been
+        registered.
+        """
+        if cls.__parser is not None:
+            raise RuntimeError("Options can not be registered more than once")
+
+        # Saving the parser for late option registration
+        cls.__parser = parser
+
+        # We setup all the options that are already registered
+        for group_name, parameters in cls.test_parameter_groups().items():
+            for param in parameters:
+                TestParameterRegistry.add_option(parser, group_name, param)
 
 
 class TestParameter(Generic[ParameterType]):

--- a/pytest_inmanta/test_parameter/parameter.py
+++ b/pytest_inmanta/test_parameter/parameter.py
@@ -153,9 +153,8 @@ class TestParameterRegistry:
         It will register the parser for later use and setup all the options that have already been
         registered.
         """
-        if cls.__parser is not None:
-            # Options can not be registered more than once
-            return
+        if cls.__parser == parser:
+            raise RuntimeError("Options can not be registered more than once")
 
         # Saving the parser for late option registration
         cls.__parser = parser


### PR DESCRIPTION
# Description

Allow other pytest plugin to use the test_parameter framework, even if they are loaded after pytest-inmanta plugin.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
