### PR TITLE
Issue/fix incomplete parameter registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 2.4.0 (?)
 Changes in this release:
 
+# v 2.3.3 (2022-05-17)
+Changes in this release:
+ - Fix enum test parameters registered after pytest has loaded pytest-inmanta plugin.
+
 # v 2.3.2 (2022-05-17)
 Changes in this release:
  - Allow other plugins to register test parameters after pytest has loaded pytest-inmanta plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 2.4.0 (?)
 Changes in this release:
 
-# v 2.3.3 (2022-05-17)
+# v 2.3.3 (2022-05-18)
 Changes in this release:
  - Fix enum test parameters registered after pytest has loaded pytest-inmanta plugin.
 

--- a/pytest_inmanta/test_parameter/enum_parameter.py
+++ b/pytest_inmanta/test_parameter/enum_parameter.py
@@ -53,6 +53,7 @@ class EnumTestParameter(TestParameter[E]):
         group: Optional[str] = None,
         legacy: Optional["EnumTestParameter[E]"] = None,
     ) -> None:
+        self.enum = enum
         super().__init__(
             argument,
             environment_variable,
@@ -62,7 +63,6 @@ class EnumTestParameter(TestParameter[E]):
             group=group,
             legacy=legacy,
         )
-        self.enum = enum
 
     @property
     def choices(self) -> Optional[Container[str]]:

--- a/pytest_inmanta/test_parameter/path_parameter.py
+++ b/pytest_inmanta/test_parameter/path_parameter.py
@@ -57,6 +57,8 @@ class PathTestParameter(TestParameter[Path]):
         is_file: Optional[bool] = None,
         exists: Optional[bool] = None,
     ) -> None:
+        self.is_file = is_file
+        self.exists = exists if is_file is None else True
         super().__init__(
             argument,
             environment_variable,
@@ -66,8 +68,6 @@ class PathTestParameter(TestParameter[Path]):
             group=group,
             legacy=legacy,
         )
-        self.is_file = is_file
-        self.exists = exists if is_file is None else True
 
     def validate(self, raw_value: object) -> Path:
         path = Path(str(raw_value)).absolute()


### PR DESCRIPTION
# Description

If an `EnumTestParameter` is registered after pytest called `pytest_addoption` in pytest-inmanta, it will be added to the parser immediatly.  This didn't work because when creating the option, we get the choices, which are computed based on the enum that has been assigned to parameter, except that this enum is not yet assigned as the object is not complete yet (the registration happens in the __init__ method of the parent, which was called before attaching the enum to the object.  This PR fixes this, we now attach the enum to the object before calling the parent constructor.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
