### PR TITLE
Improve project fixture initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 2.4.0 (?)
 Changes in this release:
 - Add fixture to change the Inmanta state dir to a writable location for the current user.
+- Improve performance in the initialization of the project fixture
 
 # v 2.3.3 (2022-05-18)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -626,7 +626,6 @@ class Project:
         ] = defaultdict(dict)
         self._should_load_plugins: typing.Optional[bool] = load_plugins
         self._plugins: typing.Optional[typing.Dict[str, FunctionType]] = None
-        self._load()
         self._capsys: typing.Optional["CaptureFixture"] = None
         self.ctx: typing.Optional[HandlerContext] = None
         self._handlers: typing.Set[ResourceHandler] = set()


### PR DESCRIPTION
# Description

About the problems mentioned in the ticket:
1. The venv isn't actually recreated when the option is used, but the logging is misleading, ticket to improve it: inmanta/inmanta-core#4343
2. The calls to pip are related to loading the project and downloading the dependencies of the module (this is indeed takes up most of the run time) on **iso5 stable**

This was done 3 times with the example test case of the empty module initialized with cookiecutter:
1. When the `Project` object is created (with the model `import module`)
2. When `project` fixture is initialized (with the model `import module`)
4. During the test case in the call to `project.compile()` (with the model defined in the test case)

If my understanding is correct, then I think 1. can be removed, because we always use the project via the fixture that calls `project.init()`, and other features of the project (e.g., `capsys`) are also only initialized in the fixture. 
This object is reused though, so it is only a very minor improvement when running multiple test cases, but when running them one-by-one it can count.
2 is necessary for loading the plugins for example
3 is also necessary because the model in the test case may import other modules that have to be downloaded

closes #299 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
