### PR TITLE
Issue/3470 unserializable items in the changes set make the crud handler get stuck in updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 2.4.0 (?)
 Changes in this release:
 - Add fixture to change the Inmanta state dir to a writable location for the current user.
+- Ensure logs can be serialized in finalize_context
 
 # v 2.3.3 (2022-05-18)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -735,7 +735,10 @@ class Project:
 
     def finalize_context(self, ctx: handler.HandlerContext) -> None:
         # ensure logs can be serialized
-        json_encode({"message": ctx.logs})
+        try:
+            json_encode({"message": ctx.logs})
+        except TypeError as e:
+            raise Exception(f"Unserializable logs. : {ctx.logs}") from e
 
     def get_resource(
         self, resource_type: str, **filter_args: object


### PR DESCRIPTION
# Description

Ensure logs can be serialized in finalize_context

Part of [#3470](https://github.com/inmanta/inmanta-core/issues/3470)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
