### PR TITLE
fixed flake8 considering examples as separate projects with separate black config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ copyright-check=True
 copyright-author=Inmanta
 # C errors are not selected by default, so add them to the selection
 select = E,F,W,C,BLK,I
+# make sure projects in examples dir are never considered as separate projects rather than depending on how check is invoked
+black-config=pyproject.toml
 
 [isort]
 profile=black


### PR DESCRIPTION
# Description

I discovered while working on pytest-inmanta-lsm that the projects in examples would get inconsistent behavior from flake8 and black. The way we invoke black (with multiple directories) it always takes the config in this repo's root to be the authority, but flake8 did not do the same. In the case of pytest-inmanta there are currently no conflicts arising from this, but they might appear any time we make changes to or add new examples.
This pull request makes sure flake8-black always considers pytest-inmanta's root config to be the authority.

The option could also be set in the makefile as `--black-config`. I have no strong preference between the two.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
