### PR TITLE
Ensure temporary directories are cleaned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 2.5.0 (?)
 Changes in this release:
+- Fix bug where the temporary directory used to store the Inmanta project is not cleaned up when an exception occurs in the setup stage of the project\_factory fixture.
 
 # v 2.4.0 (2022-09-07)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -243,7 +243,9 @@ def project_dir() -> str:
 
 
 @pytest.fixture(scope="session")
-def project_factory(request: pytest.FixtureRequest, project_dir: str) -> typing.Callable[[], "Project"]:
+def project_factory(
+    request: pytest.FixtureRequest, project_dir: str
+) -> typing.Callable[[], "Project"]:
     """
     A factory that constructs a single Project.
     """


### PR DESCRIPTION
# Description

This PR fixes the bug where the temporary directory, used to store the Inmanta project, is not cleaned up when an exception occurs in the setup stage of the project_factory fixture.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
