### PR TITLE
marked expected test failure as xfail

### DIFF
--- a/examples/testmodule/tests/test_BadLog.py
+++ b/examples/testmodule/tests/test_BadLog.py
@@ -4,7 +4,10 @@
     License: Apache 2.0
 """
 
+import pytest
 
+
+@pytest.mark.xfail(strict=True)
 def test_badlog_run(project):
     basemodel = """
     import testmodule

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -83,7 +83,7 @@ def test_badlog(testdir):
 
     result = testdir.runpytest("tests/test_BadLog.py")
 
-    result.assert_outcomes(failed=1)
+    result.assert_outcomes(xfailed=1)
 
 
 def test_release_mode_validation(testdir):


### PR DESCRIPTION
# Description

Marked a test that is always expected to fail as `xfail`. I see the following benefits:
1. Keeps the exception trace out of the log on Jenkins. Having it there could give the impression that this is the root cause of a `pytest-inmanta` test failure, while it is actually the expected behavior.
2. Simplifies debugging: manually running this test (rather than the wrapping `pytest-inmanta` test), results in a successful run.

I didn't go to the effort of checking for all similar occurrences.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
