### PR TITLE
Fixed test cleanup issue

### DIFF
--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -442,6 +442,15 @@ class ProjectLoader:
     _dynamic_modules: typing.Set[str] = set()
 
     @classmethod
+    def reset(cls) -> None:
+        """
+        Fully resets the ProjectLoader. For normal pytest-inmanta use this is not required (or even desired). It is used for
+        resetting the singleton state in between distinct module tests for pytest-inmanta's own test suite.
+        """
+        cls._registered_plugins = {}
+        cls._dynamic_modules = set()
+
+    @classmethod
     def load(cls, project: module.Project) -> None:
         """
         Sets and loads the given project.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,12 @@ def set_cwd(testdir):
 
 
 @pytest.fixture(scope="function", autouse=True)
+def reset_pytest_inmanta_state():
+    yield
+    pytest_inmanta.plugin.ProjectLoader.reset()
+
+
+@pytest.fixture(scope="function", autouse=True)
 def deactive_venv():
     old_os_path = os.environ.get("PATH", "")
     old_prefix = sys.prefix


### PR DESCRIPTION
# Description

Added missing cleanup between pytest-inmanta (meta) tests. This caused subtle issues when the example projects being tested used different versions of the same module, specifically when the version that was installed first had a plugin that did not exist in the other version.

The `ProjectLoader` singleton manages plugin registration on the compiler to allow for top-level imports. To this end it caches any registered plugins in between compiles. For normal pytest-inmanta usage this is valid because all compiles are based on the same project, with the same requirements, in the same venv. The pytest-inmanta test suite howeve triggers multiple `pytest` runs on different modules (unless `--runpytest=subprocess` is set). In this case, this singleton state is still valid between compiles for a single test run, but it should be reset in between test runs. This PR adds that reset.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] ~~Changelog entry~~
- [x] Code is clear and sufficiently documented
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
