### PR TITLE
Added dryrun_all and dryrun_and_deploy_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 Changes in this release:
 - Add `dryrun_all` method to  the `project` fixture. Does a dryrun on every resource of a project. Also does some sanity checks.
 - Add `dryrun_and_deploy_all` method to the `project` fixture. Dryruns, deploys and does a final dryrun on every resource of a project. Also does some sanity checks.
-These functions will help to write tests as they will reduce a lot of boilerplate code.
 # v 2.5.0 (2023-01-20)
 Changes in this release:
 - Fix bug where the temporary directory used to store the Inmanta project is not cleaned up when an exception occurs in the setup stage of the project\_factory fixture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v 2.6.0 (?)
 Changes in this release:
-
+- Add `dryrun_all` method to  the `project` fixture. Does a dryrun on every resource of a project. Also does some sanity checks.
+- Add `dryrun_and_deploy_all` method to the `project` fixture. Dryruns, deploys and does a final dryrun on every resource of a project. Also does some sanity checks.
+These functions will help to write tests as they will reduce a lot of boilerplate code.
 # v 2.5.0 (2023-01-20)
 Changes in this release:
 - Fix bug where the temporary directory used to store the Inmanta project is not cleaned up when an exception occurs in the setup stage of the project\_factory fixture.

--- a/README.md
+++ b/README.md
@@ -70,22 +70,23 @@ And dryrun
     changes = project.dryrun_resource("testmodule::Resource")
     assert changes == {"value": {'current': 'read', 'desired': 'write'}}
     # Or dryrun all resources at once
-    project.dryrun_all()
+    result = project.dryrun_all()
+    result.assert_expected_behaviour()
 ```
 
 It is also possible to deploy all resources at once:
 
 ```python
     results = project.deploy_all()
-    results.assert_all(status=ResourceState.deployed)
+    results.assert_expected_behaviour()
     assert results.get_context_for("std::ConfigFile", path="/tmp/test").status == ResourceState.deployed
 ```
 
 For convenience, it is also possible to dryrun and deploy all resources at once.
-This method also asserts that a dryrun after the deploy will not have changes:
+This method also asserts that the dryruns and deploys pass some sanity checks.
 
 ```python
-    project.dryrun_and_deploy_all()
+    project.dryrun_and_deploy_all(assert_create_or_delete=True)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ And dryrun
 ```python
     changes = project.dryrun_resource("testmodule::Resource")
     assert changes == {"value": {'current': 'read', 'desired': 'write'}}
+    # Or dryrun all resources at once
+    project.dryrun_all()
 ```
 
 It is also possible to deploy all resources at once:
@@ -78,6 +80,14 @@ It is also possible to deploy all resources at once:
     results.assert_all(status=ResourceState.deployed)
     assert results.get_context_for("std::ConfigFile", path="/tmp/test").status == ResourceState.deployed
 ```
+
+For convenience, it is also possible to dryrun and deploy all resources at once.
+This method also asserts that a dryrun after the deploy will not have changes:
+
+```python
+    project.dryrun_and_deploy_all()
+```
+
 
 Testing functions and classes defined in a v1 module is also possible
 using the `inmanta_plugins` fixture. The fixture exposes inmanta modules as its attributes

--- a/README.md
+++ b/README.md
@@ -79,12 +79,48 @@ It is also possible to deploy all resources at once:
     results = project.deploy_all()
     assert results.get_context_for("std::ConfigFile", path="/tmp/test").status == ResourceState.deployed
 ```
+The `dryrun_all` and `deploy_all` functions return a `Result` object with
+some helpful auxiliary functions to assert some sanity checks.
 
-For convenience, it is also possible to dryrun and deploy all resources at once.
-This method also asserts that the dryruns and deploys pass some sanity checks.
+We can check if every resource on the result has the correct state:
+```python
+    results = project.dryrun_all()
+    results.assert_all(ResourceState.dry)
+```
+
+It is possible to determine if every resource has the attribute `purged` in its changes.
+This is helpful to assert if the resources are to be created (`purged` set to True) or deleted (`purged` set to False):
+```python
+    results = project.dryrun_all()
+    results.assert_resources_have_purged()
+```
+
+The same applies to a `deploy_all`:
+```python
+    results = project.deploy_all()
+    results.assert_all(ResourceState.deployed)
+```
+
+To check if a deploy is successful and we achieved the desired state,
+it is possible to do a dryrun after the deploy and check if there are no changes:
 
 ```python
-    project.dryrun_and_deploy_all(assert_create_or_delete=True)
+    results = project.deploy_all()
+    results.assert_all(ResourceState.deployed)
+
+    results = project.dryrun_all()
+    results.assert_has_no_changes()
+```
+
+For convenience, it is also possible to dryrun and deploy all resources at once.
+This method also asserts that the dryruns and deploys pass the sanity checks above.
+It returns a `DeployResultCollection` that aggregates the `Results` from the dryruns and the deploy.
+
+```python
+    resutls = project.dryrun_and_deploy_all(assert_create_or_delete=True)
+    results.first_dryrun.assert_all(ResourceState.dry)
+    results.deploy.assert_all(ResourceState.deployed)
+    results.last_dryrun.assert_all(ResourceState.dry)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,12 @@ And dryrun
     assert changes == {"value": {'current': 'read', 'desired': 'write'}}
     # Or dryrun all resources at once
     result = project.dryrun_all()
-    result.assert_expected_behaviour()
 ```
 
 It is also possible to deploy all resources at once:
 
 ```python
     results = project.deploy_all()
-    results.assert_expected_behaviour()
     assert results.get_context_for("std::ConfigFile", path="/tmp/test").status == ResourceState.deployed
 ```
 

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -61,5 +61,3 @@ def test_dryrun_all(project):
     )
     results = project.dryrun_all().values()
     assert len(results) == 3
-    for result in results:
-        assert "purged" in result

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -62,14 +62,14 @@ def test_dryrun_all(project):
     """
     )
     result = project.dryrun_all()
-    ctx = result.get_context_for("unittest::Resource", name="res")
-    assert ctx.resource.desired_value == "x"
+    resource = result.get_resource("unittest::Resource", name="res")
+    assert resource.desired_value == "x"
 
-    ctx = result.get_context_for("unittest::Resource", name="res2")
-    assert ctx.resource.desired_value == "y"
+    resource = result.get_resource("unittest::Resource", name="res2")
+    assert resource.desired_value == "y"
 
-    ctx = result.get_context_for("unittest::Resource", name="res3")
-    assert ctx.resource.desired_value == "z"
+    resource = result.get_resource("unittest::Resource", name="res3")
+    assert resource.desired_value == "z"
 
 
 def test_failures_in_dryrun_all(project):

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -18,6 +18,7 @@
 from inmanta import const
 import pytest
 
+
 def test_dryrun(project):
     project.compile(
         """
@@ -72,7 +73,7 @@ def test_dryrun_all(project):
 
 def test_failures_in_dryrun_all(project):
     project.compile(
-    """
+        """
     import unittest
 
     unittest::Resource(name="res", desired_value="x")
@@ -83,6 +84,7 @@ def test_failures_in_dryrun_all(project):
     result = project.dryrun_all()
     with pytest.raises(AssertionError, match="has status failed, expected dry"):
         result.assert_expected_behaviour()
+
 
 def test_dryrun_and_deploy_all(project):
     project.compile(
@@ -96,9 +98,10 @@ def test_dryrun_and_deploy_all(project):
     )
     project.dryrun_and_deploy_all(assert_create_or_delete=True)
 
+
 def test_failures_in_dryrun_and_deploy_all(project):
     project.compile(
-    """
+        """
     import unittest
 
     unittest::Resource(name="res", desired_value="x")

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -59,7 +59,7 @@ def test_dryrun_all(project):
     unittest::Resource(name="res3", desired_value="z")
     """
     )
-    project.dryrun_all(first_dry=True).values()
+    project.dryrun_all(assert_create_or_delete=True).values()
 
 
 def test_dryrun_and_deploy_all(project):
@@ -72,4 +72,4 @@ def test_dryrun_and_deploy_all(project):
     unittest::Resource(name="res3", desired_value="z")
     """
     )
-    project.dryrun_and_deploy_all(first_dry=True)
+    project.dryrun_and_deploy_all(assert_create_or_delete=True)

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -15,8 +15,9 @@
 
     Contact: code@inmanta.com
 """
-from inmanta import const
 import pytest
+
+from inmanta import const
 
 
 def test_dryrun(project):
@@ -83,7 +84,7 @@ def test_failures_in_dryrun_all(project):
     )
     result = project.dryrun_all()
     with pytest.raises(AssertionError, match="has status failed, expected dry"):
-        result.assert_expected_behaviour()
+        result.assert_all(const.ResourceState.dry)
 
 
 def test_dryrun_and_deploy_all(project):

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -112,3 +112,29 @@ def test_failures_in_dryrun_and_deploy_all(project):
     )
     with pytest.raises(AssertionError, match="has status failed, expected dry"):
         project.dryrun_and_deploy_all(assert_create_or_delete=True)
+
+
+def test_failures_in_deploy_only(project):
+    project.compile(
+        """
+    import unittest
+
+    unittest::Resource(name="res", desired_value="x")
+    unittest::Resource(name="res2", desired_value="y", fail_deploy=true)
+    unittest::Resource(name="res3", desired_value="z")
+    """
+    )
+    with pytest.raises(AssertionError, match="has status failed, expected deployed"):
+        project.dryrun_and_deploy_all(assert_create_or_delete=True)
+
+
+def test_failures_in_last_dryrun(project):
+    project.compile(
+        """
+    import unittest
+
+    unittest::WrongDiffResource(name="res", desired_value="x")
+    """
+    )
+    with pytest.raises(AssertionError, match="expected no changes"):
+        project.dryrun_and_deploy_all(assert_create_or_delete=True)

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -47,3 +47,16 @@ def test_dryrun_fail_skip(project):
         """
     )
     project.dryrun_resource("unittest::Resource", status=const.ResourceState.skipped)
+
+def test_dryrun_all(project):
+    project.compile(
+        """
+    import unittest
+
+    unittest::Resource(name="res", desired_value="x")
+    unittest::Resource(name="res2", desired_value="y")
+    unittest::Resource(name="res3", desired_value="z")
+    """
+    )
+    result = project.dryrun_all("unittest::Resource", status=const.ResourceState.dry)
+    assert result

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -133,7 +133,7 @@ def test_failures_in_last_dryrun(project):
         """
     import unittest
 
-    unittest::WrongDiffResource(name="res", desired_value="x")
+    unittest::Resource(name="res", desired_value="x", wrong_diff=true)
     """
     )
     with pytest.raises(AssertionError, match="expected no changes"):

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -59,8 +59,7 @@ def test_dryrun_all(project):
     unittest::Resource(name="res3", desired_value="z")
     """
     )
-    results = project.dryrun_all().values()
-    assert len(results) == 3
+    project.dryrun_all(first_dry=True).values()
 
 
 def test_dryrun_and_deploy_all(project):
@@ -73,4 +72,4 @@ def test_dryrun_and_deploy_all(project):
     unittest::Resource(name="res3", desired_value="z")
     """
     )
-    project.dryrun_and_deploy_all()
+    project.dryrun_and_deploy_all(first_dry=True)

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -48,6 +48,7 @@ def test_dryrun_fail_skip(project):
     )
     project.dryrun_resource("unittest::Resource", status=const.ResourceState.skipped)
 
+
 def test_dryrun_all(project):
     project.compile(
         """
@@ -58,5 +59,7 @@ def test_dryrun_all(project):
     unittest::Resource(name="res3", desired_value="z")
     """
     )
-    result = project.dryrun_all("unittest::Resource", status=const.ResourceState.dry)
-    assert result
+    results = project.dryrun_all().values()
+    assert len(results) == 3
+    for result in results:
+        assert "purged" in result

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -61,3 +61,16 @@ def test_dryrun_all(project):
     )
     results = project.dryrun_all().values()
     assert len(results) == 3
+
+
+def test_dryrun_and_deploy_all(project):
+    project.compile(
+        """
+    import unittest
+
+    unittest::Resource(name="res", desired_value="x")
+    unittest::Resource(name="res2", desired_value="y")
+    unittest::Resource(name="res3", desired_value="z")
+    """
+    )
+    project.dryrun_and_deploy_all()

--- a/examples/testhandler/tests/test_full_deploy.py
+++ b/examples/testhandler/tests/test_full_deploy.py
@@ -40,7 +40,7 @@ def test_full_deploy(project):
     )
 
     results = project.deploy_all()
-    results.assert_expected_behaviour()
+    results.assert_all(ResourceState.deployed)
 
     DATA["r_skip"]["skip"] = True
     DATA["r_fail"]["fail"] = True

--- a/examples/testhandler/tests/test_full_deploy.py
+++ b/examples/testhandler/tests/test_full_deploy.py
@@ -40,7 +40,7 @@ def test_full_deploy(project):
     )
 
     results = project.deploy_all()
-    results.assert_all()
+    results.assert_expected_behaviour()
 
     DATA["r_skip"]["skip"] = True
     DATA["r_fail"]["fail"] = True

--- a/pytest_inmanta/module/init.cf
+++ b/pytest_inmanta/module/init.cf
@@ -21,12 +21,16 @@ entity Resource extends std::PurgeableResource:
         A test resource for unit and integration testing purposes.
 
         :param skip: When set to true the handler will raise a skipresource
-        :param fail: When set to true the handler will raise an exception to mark a failure
+        :param fail: When set to true the handler will raise an exception to mark a failure whenever it performs a CRUD
+            operation.
+        :param fail_deploy: When set to true the handler will raise an exception to mark a failure when it actually performs
+            a deploy operation, i.e. create, update, delete.
     """
     string name
     string desired_value
     bool skip=false
     bool fail=false
+    bool fail_deploy=false
     string agent="internal"
 end
 
@@ -34,6 +38,27 @@ index Resource(name)
 
 implement Resource using std::none
 
+entity WrongDiffResource extends std::PurgeableResource:
+    """
+        A test resource with a faulty calculate_diff. 
+
+        :param skip: When set to true the handler will raise a skipresource
+        :param fail: When set to true the handler will raise an exception to mark a failure whenever it performs a CRUD
+            operation.
+        :param fail_deploy: When set to true the handler will raise an exception to mark a failure when it actually performs
+            a deploy operation, i.e. create, update, delete.
+    """
+    string name
+    string desired_value
+    bool skip=false
+    bool fail=false
+    bool fail_deploy=false
+    string agent="internal"
+end
+
+index WrongDiffResource(name)
+
+implement WrongDiffResource using std::none
 
 entity IgnoreResource extends std::PurgeableResource:
     """

--- a/pytest_inmanta/module/init.cf
+++ b/pytest_inmanta/module/init.cf
@@ -25,12 +25,15 @@ entity Resource extends std::PurgeableResource:
             operation.
         :param fail_deploy: When set to true the handler will raise an exception to mark a failure when it actually performs
             a deploy operation, i.e. create, update, delete.
+        :param wrong_diff: When set to true the handler will return a wrong diff result.
+            Causes dryrun_and_deploy_all to fail on the last dryrun.
     """
     string name
     string desired_value
     bool skip=false
     bool fail=false
     bool fail_deploy=false
+    bool wrong_diff=false
     string agent="internal"
 end
 
@@ -38,27 +41,6 @@ index Resource(name)
 
 implement Resource using std::none
 
-entity WrongDiffResource extends std::PurgeableResource:
-    """
-        A test resource with a faulty calculate_diff. 
-
-        :param skip: When set to true the handler will raise a skipresource
-        :param fail: When set to true the handler will raise an exception to mark a failure whenever it performs a CRUD
-            operation.
-        :param fail_deploy: When set to true the handler will raise an exception to mark a failure when it actually performs
-            a deploy operation, i.e. create, update, delete.
-    """
-    string name
-    string desired_value
-    bool skip=false
-    bool fail=false
-    bool fail_deploy=false
-    string agent="internal"
-end
-
-index WrongDiffResource(name)
-
-implement WrongDiffResource using std::none
 
 entity IgnoreResource extends std::PurgeableResource:
     """

--- a/pytest_inmanta/module/init.py
+++ b/pytest_inmanta/module/init.py
@@ -27,12 +27,7 @@ KEY_PREFIX = "unittest_"
 
 @resources.resource("unittest::Resource", id_attribute="name", agent="agent")
 class Resource(resources.PurgeableResource):
-    fields = ("name", "desired_value", "skip", "fail", "fail_deploy")
-
-
-@resources.resource("unittest::WrongDiffResource", id_attribute="name", agent="agent")
-class WrongDiffResource(resources.PurgeableResource):
-    fields = ("name", "desired_value", "skip", "fail", "fail_deploy")
+    fields = ("name", "desired_value", "skip", "fail", "fail_deploy", "wrong_diff")
 
 
 @handler.provider("unittest::Resource", name="test")
@@ -95,16 +90,15 @@ class ResourceHandler(handler.CRUDHandler):
 
         ctx.set_updated()
 
-
-@handler.provider("unittest::WrongDiffResource", name="test")
-class WrongDiffResourceHandler(ResourceHandler):
     def calculate_diff(
         self,
         ctx: handler.HandlerContext,
         current: resources.Resource,
         desired: resources.Resource,
     ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
-        return {"desired_value": {"current": "x", "desired": "y"}}
+        if current.wrong_diff:
+            return {"desired_value": {"current": "x", "desired": "y"}}
+        return super().calculate_diff(ctx, current, desired)
 
 
 @resources.resource("unittest::IgnoreResource", id_attribute="name", agent="agent")

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -619,8 +619,8 @@ class Result:
 
     def assert_has_no_changes(self) -> None:
         for r, ct in self.results.items():
-            assert (
-                ct.change is const.Change.nochange
+            assert not bool(
+                ct.changes
             ), f"Resource {r.id} has changes {ct.changes}, expected no changes"
 
     def assert_resources_have_purged(self) -> None:
@@ -858,7 +858,7 @@ class Project:
 
         assert h is not None
 
-        ctx = handler.HandlerContext(resource)
+        ctx = handler.HandlerContext(resource, dry_run=dry_run)
         h.execute(ctx, resource, dry_run)
         self.finalize_context(ctx)
         self.ctx = ctx

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -668,10 +668,10 @@ class Result:
         return get_resource(self.results.keys(), resource_type, **filter_args)
 
 
-class DeployResult(Result):
-    """
-    Here for backwards compatibility reasons.
-    """
+DeployResult = Result
+"""
+Here for backwards compatibility reasons.
+"""
 
 
 @dataclass

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1012,9 +1012,8 @@ class Project:
         :param dryrun_type: determines what type of DryrunResult to create
         """
         results = {
-                r: self.dryrun(r, run_as_root=run_as_root)
-                for r in self.resources.values()
-            }
+            r: self.dryrun(r, run_as_root=run_as_root) for r in self.resources.values()
+        }
         if dryrun_type == DryrunType.empty:
             return EmptyDryrunResult(results)
         if dryrun_type == DryrunType.create_or_delete:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -982,7 +982,6 @@ class Project:
         deploy_result = self.deploy_all(run_as_root=run_as_root)
 
         assert not self.dryrun_all(run_as_root=run_as_root)
-        assert dryrun_result == deploy_result.results
         return {"dryrun": dryrun_result, "deploy": deploy_result.results}
 
     def io(self, run_as_root: bool = False) -> "IOBase":

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -950,6 +950,47 @@ class Project:
         ctx = self.dryrun(res, run_as_root)
         assert ctx.status == status
         return ctx.changes
+    
+    def dryrun_all(
+        self,
+        status: const.ResourceState = const.ResourceState.dry,
+        run_as_root: bool = False
+    ) -> Dict[str, typing.Dict[str, AttributeStateChange]]:
+        result = {}
+        for rid, resource in self.resources.items():
+            result[rid] = self.dryrun_resource(resource, status, run_as_root)
+        return result
+
+    # def evaluate_correct_resource_behaviour(
+    #     self, resource_types: List, first_dry: bool = False
+    # ):
+    #     """
+    #     Runs a dryrun, followed by a deploy and a final dryrun for a list of resources and asserts the expected behaviour.
+
+    #     :param resource_types: a list of the types of resource to run, as a fully qualified inmanta types each entry may
+    #         also include additional filter arguments (e.g. [`unittest::Resource`, (`unittest::Resource`, {`myid`:`test.1`} )] )
+    #     :param first_dry: check if `purged` is in the result of the first dryrun, useful to confirm that
+    #         the resource was not already deployed
+    #     """
+
+    #     for current_type in resource_types:
+    #         if len(current_type) == 2:
+    #             current_type, filter_args = current_type
+    #         else:
+    #             filter_args = None
+    #         result = self.dryrun_resource(current_type)
+
+    #         if first_dry:
+    #             assert "purged" in result
+
+    #         if filter_args is None:
+    #             self.deploy_resource(current_type)
+    #             result = self.dryrun_resource(current_type)
+    #         else:
+    #             self.deploy_resource(current_type, **filter_args)
+    #             result = self.dryrun_resource(current_type, **filter_args)
+
+    #         assert not result
 
     def io(self, run_as_root: bool = False) -> "IOBase":
         version = 1

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -675,7 +675,7 @@ class DeployResult(Result):
 
 
 @dataclass
-class ResultCollection:
+class DeployResultCollection:
     first_dryrun: Result
     deploy: Result
     last_dryrun: Result
@@ -1020,7 +1020,7 @@ class Project:
 
     def dryrun_and_deploy_all(
         self, run_as_root: bool = False, assert_create_or_delete: bool = False
-    ) -> ResultCollection:
+    ) -> DeployResultCollection:
         """
         Runs a dryrun, followed by a deploy and a final dryrun for every resource and asserts the expected behaviour.
         :param run_as_root: run the mock agent as root
@@ -1039,7 +1039,7 @@ class Project:
         last_dryrun.assert_all(const.ResourceState.dry)
         last_dryrun.assert_has_no_changes()
 
-        return ResultCollection(
+        return DeployResultCollection(
             first_dryrun=first_dryrun, deploy=deploy, last_dryrun=last_dryrun
         )
 

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -953,12 +953,11 @@ class Project:
     
     def dryrun_all(
         self,
-        status: const.ResourceState = const.ResourceState.dry,
         run_as_root: bool = False
     ) -> Dict[str, typing.Dict[str, AttributeStateChange]]:
         result = {}
-        for rid, resource in self.resources.items():
-            result[rid] = self.dryrun_resource(resource, status, run_as_root)
+        for resource in self.resources.values():
+            result[resource.id] = self.dryrun(resource, run_as_root=run_as_root).changes
         return result
 
     # def evaluate_correct_resource_behaviour(

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -953,43 +953,25 @@ class Project:
     
     def dryrun_all(
         self,
-        run_as_root: bool = False
+        run_as_root: bool = False,
+        first_dry: bool = False
     ) -> Dict[str, typing.Dict[str, AttributeStateChange]]:
-        result = {}
+        """
+        Runs a dryrun for every resource.
+        :param run_as_root: run the mock agent as root
+        :param first_dry: check if `purged` is in the result of the dryrun, useful to confirm that
+            the resource was not already deployed
+        """
+        results = {}
         for resource in self.resources.values():
-            result[resource.id] = self.dryrun(resource, run_as_root=run_as_root).changes
-        return result
+            changes = self.dryrun(resource, run_as_root=run_as_root).changes
+            if first_dry:
+                assert "purged" in changes
+            results[resource.id] = changes
+        return results
 
-    # def evaluate_correct_resource_behaviour(
-    #     self, resource_types: List, first_dry: bool = False
-    # ):
-    #     """
-    #     Runs a dryrun, followed by a deploy and a final dryrun for a list of resources and asserts the expected behaviour.
 
-    #     :param resource_types: a list of the types of resource to run, as a fully qualified inmanta types each entry may
-    #         also include additional filter arguments (e.g. [`unittest::Resource`, (`unittest::Resource`, {`myid`:`test.1`} )] )
-    #     :param first_dry: check if `purged` is in the result of the first dryrun, useful to confirm that
-    #         the resource was not already deployed
-    #     """
 
-    #     for current_type in resource_types:
-    #         if len(current_type) == 2:
-    #             current_type, filter_args = current_type
-    #         else:
-    #             filter_args = None
-    #         result = self.dryrun_resource(current_type)
-
-    #         if first_dry:
-    #             assert "purged" in result
-
-    #         if filter_args is None:
-    #             self.deploy_resource(current_type)
-    #             result = self.dryrun_resource(current_type)
-    #         else:
-    #             self.deploy_resource(current_type, **filter_args)
-    #             result = self.dryrun_resource(current_type, **filter_args)
-
-    #         assert not result
 
     def io(self, run_as_root: bool = False) -> "IOBase":
         version = 1

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -30,7 +30,6 @@ import typing
 import warnings
 from collections import defaultdict
 from distutils import dir_util
-from enum import Enum
 from itertools import chain
 from pathlib import Path
 from textwrap import dedent

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -30,4 +30,4 @@ def test_dryrun(testdir):
 
     result = testdir.runpytest("tests/test_dryrun.py")
 
-    result.assert_outcomes(passed=4)
+    result.assert_outcomes(passed=6)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -30,4 +30,4 @@ def test_dryrun(testdir):
 
     result = testdir.runpytest("tests/test_dryrun.py")
 
-    result.assert_outcomes(passed=6)
+    result.assert_outcomes(passed=8)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -30,4 +30,4 @@ def test_dryrun(testdir):
 
     result = testdir.runpytest("tests/test_dryrun.py")
 
-    result.assert_outcomes(passed=2)
+    result.assert_outcomes(passed=4)


### PR DESCRIPTION
# Description

Added a function to dryrun every resource and do some sanity checks.
Added another function to do a dryrun followed by a deploy and another dryrun. 
These workflows are used a lot in testing and these functions would eliminate a lot of boilerplate code.

Still missing some documentation

closes #358