### PR TITLE
Issue/re write state dir in project

### DIFF
--- a/examples/testmodulev2/inmanta_plugins/testmodulev2/__init__.py
+++ b/examples/testmodulev2/inmanta_plugins/testmodulev2/__init__.py
@@ -3,9 +3,64 @@
     Contact: code@inmanta.com
     License: Apache 2.0
 """
+import pathlib
+
+import inmanta.agent.handler
+import inmanta.config
+import inmanta.resources
 from inmanta.plugins import plugin
 
 
 @plugin
 def myplugin(x: "int") -> "int":
     return x
+
+
+@inmanta.resources.resource("testmodulev2::Print", "file", "agent.agentname")
+class PrintResource(inmanta.resources.PurgeableResource):
+    fields = (
+        "file",
+        "value",
+    )
+
+
+@inmanta.agent.handler.provider("testmodulev2::Print", "base")
+class PrintProvider(inmanta.agent.handler.CRUDHandler):
+    def path(self, resource: inmanta.resources.PurgeableResource) -> pathlib.Path:
+        # If the path is absolute, return the absolute path, if it is relative,
+        # consider it relative to the agent state dir, and return the absolute
+        # path equivalent.
+        return pathlib.Path(inmanta.config.state_dir.get(), resource.file)
+
+    def read_resource(
+        self,
+        ctx: inmanta.agent.handler.HandlerContext,
+        resource: inmanta.resources.PurgeableResource,
+    ) -> None:
+        if not self.path(resource).exists():
+            raise inmanta.agent.handler.ResourcePurged()
+
+        resource.value = self.path(resource).read_text()
+
+    def create_resource(
+        self,
+        ctx: inmanta.agent.handler.HandlerContext,
+        resource: inmanta.resources.PurgeableResource,
+    ) -> None:
+        self.path(resource).parent.mkdir(parents=True, exist_ok=True)
+        self.path(resource).write_text(resource.value)
+
+    def update_resource(
+        self,
+        ctx: inmanta.agent.handler.HandlerContext,
+        changes: dict[str, dict[str, object]],
+        resource: inmanta.resources.PurgeableResource,
+    ) -> None:
+        self.path(resource).write_text(resource.value)
+
+    def delete_resource(
+        self,
+        ctx: inmanta.agent.handler.HandlerContext,
+        resource: inmanta.resources.PurgeableResource,
+    ) -> None:
+        self.path(resource).unlink()

--- a/examples/testmodulev2/inmanta_plugins/testmodulev2/__init__.py
+++ b/examples/testmodulev2/inmanta_plugins/testmodulev2/__init__.py
@@ -16,11 +16,11 @@ def myplugin(x: "int") -> "int":
     return x
 
 
-@inmanta.resources.resource("testmodulev2::Print", "file", "agent.agentname")
+@inmanta.resources.resource("testmodulev2::Print", "file", "agent_name")
 class PrintResource(inmanta.resources.PurgeableResource):
     fields = (
         "file",
-        "value",
+        "content",
     )
 
 
@@ -40,7 +40,7 @@ class PrintProvider(inmanta.agent.handler.CRUDHandler):
         if not self.path(resource).exists():
             raise inmanta.agent.handler.ResourcePurged()
 
-        resource.value = self.path(resource).read_text()
+        resource.content = self.path(resource).read_text()
 
     def create_resource(
         self,
@@ -48,7 +48,7 @@ class PrintProvider(inmanta.agent.handler.CRUDHandler):
         resource: inmanta.resources.PurgeableResource,
     ) -> None:
         self.path(resource).parent.mkdir(parents=True, exist_ok=True)
-        self.path(resource).write_text(resource.value)
+        self.path(resource).write_text(resource.content)
 
     def update_resource(
         self,
@@ -56,7 +56,7 @@ class PrintProvider(inmanta.agent.handler.CRUDHandler):
         changes: dict[str, dict[str, object]],
         resource: inmanta.resources.PurgeableResource,
     ) -> None:
-        self.path(resource).write_text(resource.value)
+        self.path(resource).write_text(resource.content)
 
     def delete_resource(
         self,

--- a/examples/testmodulev2/model/_init.cf
+++ b/examples/testmodulev2/model/_init.cf
@@ -1,1 +1,8 @@
+entity Print extends std::PurgeableResource:
+    string file
+    string value
+end
 
+index Print(file)
+
+implement Print using std::none

--- a/examples/testmodulev2/model/_init.cf
+++ b/examples/testmodulev2/model/_init.cf
@@ -1,6 +1,7 @@
 entity Print extends std::PurgeableResource:
     string file
-    string value
+    string content
+    string agent_name = "default"
 end
 
 index Print(file)

--- a/examples/testmodulev2/tests/test_print_handler.py
+++ b/examples/testmodulev2/tests/test_print_handler.py
@@ -1,0 +1,35 @@
+"""
+    Copyright 2023 Inmanta
+    Contact: code@inmanta.com
+    License: Apache 2.0
+"""
+import pathlib
+
+import pytest_inmanta.plugin
+
+
+def test_compile(
+    project: pytest_inmanta.plugin.Project,
+    inmanta_state_dir: str,
+    set_inmanta_state_dir: None,
+) -> None:
+    """
+    Verify that basic compilation using the project fixture works for v2 modules.
+    """
+    model = """
+        import testmodulev2
+
+        testmodulev2::Print(
+            file="test.txt",
+            content="aha",
+        )
+    """.strip(
+        "\n"
+    )
+
+    project.compile(model, no_dedent=False)
+    assert project.dryrun("testmodulev2::Print")
+    assert project.deploy_resource("testmodulev2::Print")
+    assert not project.dryrun("testmodulev2::Print")
+
+    assert pathlib.Path(inmanta_state_dir, "test.txt").read_text() == "aha"

--- a/examples/testmodulev2/tests/test_print_handler.py
+++ b/examples/testmodulev2/tests/test_print_handler.py
@@ -28,8 +28,8 @@ def test_compile(
     )
 
     project.compile(model, no_dedent=False)
-    assert project.dryrun("testmodulev2::Print")
+    assert project.dryrun_resource("testmodulev2::Print")
     assert project.deploy_resource("testmodulev2::Print")
-    assert not project.dryrun("testmodulev2::Print")
+    assert not project.dryrun_resource("testmodulev2::Print")
 
     assert pathlib.Path(inmanta_state_dir, "test.txt").read_text() == "aha"

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -737,7 +737,7 @@ class Project:
         self.ctx: typing.Optional[HandlerContext] = None
         self._handlers: typing.Set[ResourceHandler] = set()
 
-        # Save the value of the state dir, as it might have been overwritten by the 
+        # Save the value of the state dir, as it might have been overwritten by the
         # set_inmanta_state_dir fixture
         handler_state_dir = config.state_dir.get()
 
@@ -775,7 +775,7 @@ class Project:
         self._load()
         self._set_sys_executable()
 
-        # Save the value of the state dir, as it might have been overwritten by the 
+        # Save the value of the state dir, as it might have been overwritten by the
         # set_inmanta_state_dir fixture
         handler_state_dir = config.state_dir.get()
 

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -774,7 +774,16 @@ class Project:
         self._handlers = set()
         self._load()
         self._set_sys_executable()
+
+        # Save the value of the state dir, as it might have been overwritten by the 
+        # set_inmanta_state_dir fixture
+        handler_state_dir = config.state_dir.get()
+
+        # Load the config from file
         config.Config.load_config()
+
+        # Update the state dir value, to match the one that was set before
+        config.state_dir.set(handler_state_dir)
 
     def _create_project_and_load(self, model: str) -> module.Project:
         """

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -736,7 +736,16 @@ class Project:
         self._capsys: typing.Optional["CaptureFixture"] = None
         self.ctx: typing.Optional[HandlerContext] = None
         self._handlers: typing.Set[ResourceHandler] = set()
+
+        # Save the value of the state dir, as it might have been overwritten by the 
+        # set_inmanta_state_dir fixture
+        handler_state_dir = config.state_dir.get()
+
+        # Load the config from file
         config.Config.load_config()
+
+        # Update the state dir value, to match the one that was set before
+        config.state_dir.set(handler_state_dir)
 
     def _set_sys_executable(self) -> None:
         """

--- a/tests/test_basic_example_v2.py
+++ b/tests/test_basic_example_v2.py
@@ -103,3 +103,14 @@ def test_import(testdir, testmodulev2_venv_active):
     result = testdir.runpytest_inprocess("tests/test_import.py")
 
     result.assert_outcomes(passed=3)
+
+
+def test_handler(testdir, testmodulev2_venv_active):
+    """
+    Make sure that our inmanta_state_dir fixture works for modules v2
+    """
+    testdir.copy_example("testmodulev2")
+
+    result = testdir.runpytest_inprocess("tests/test_print_handler.py")
+
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
# Description

The `set_inmanta_state_dir` fixture doesn't work well with the `project` fixture, as the latter will reload the config, overwriting any other value set by the `set_inmanta_state_dir` fixture.

This PR adds:
1. A test case to reproduce the issue
2. A proposal fix, but I don't really like it to be honest, any input is welcome

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
