### PR TITLE
Add a version constraint on the virtualenv dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters=True
 requires =
     pip >= 21.0.1
     setuptools
+    # Newer versions of virtualenv don't have support to create Python3.6 venvs
     virtualenv<20.22.0
 
 [testenv:py36]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters=True
 requires =
     pip >= 21.0.1
     setuptools
+    virtualenv<20.22.0
 
 [testenv:py36]
 basepython=python3.6


### PR DESCRIPTION
# Description

Add version constraint `virtualenv<20.22.0` to the tox config. Newer version of virtualenv don't have support anymore to create a python3.6 venv. In that case we get the following error:

```
Error processing line 1 of /home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/_virtualenv.pth:

  Traceback (most recent call last):
    File "/usr/lib64/python3.6/site.py", line 168, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/_virtualenv.py", line 3
      from __future__ import annotations
                                       ^
  SyntaxError: future feature annotations is not defined

Remainder of file ignored
Error processing line 1 of /home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/_virtualenv.pth:

  Traceback (most recent call last):
    File "/usr/lib64/python3.6/site.py", line 168, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/_virtualenv.py", line 3
      from __future__ import annotations
                                       ^
  SyntaxError: future feature annotations is not defined

Remainder of file ignored
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/__main__.py", line 29, in <module>
    from pip._internal.cli.main import main as _main
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/cli/main.py", line 10, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/cli/main_parser.py", line 9, in <module>
    from pip._internal.build_env import get_runnable_pip
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/build_env.py", line 19, in <module>
    from pip._internal.cli.spinners import open_spinner
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/cli/spinners.py", line 9, in <module>
    from pip._internal.utils.logging import get_indentation
  File "/home/jenkins/workspace/ment-tools_pytest-inmanta_master/pytest-inmanta/.tox/py36-inmiso4/lib/python3.6/site-packages/pip/_internal/utils/logging.py", line 8, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~