### PR TITLE
[FIX] make new behaviour iso7+ only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changes in this release:
 - Log a warning when the id_attribute of a resource is called id.
 - Ignore `__pycache__` dirs when copying the current module to the test project dir
-- Deprecate setting pip indexes through `--module-repo` option with type `package` in favour of newly introduced `--pip-index-url` option.
+- [inmanta-core > iso7] Deprecate setting pip indexes through `--module-repo` option with type `package` in favour of newly introduced `--pip-index-url` option.
 
 # v 2.7.0 (2023-02-23)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changes in this release:
 - Log a warning when the id_attribute of a resource is called id.
 - Ignore `__pycache__` dirs when copying the current module to the test project dir
-- [inmanta-core > iso7] Deprecate setting pip indexes through `--module-repo` option with type `package` in favour of newly introduced `--pip-index-url` option.
+- Introduce `--pip-index-url` option to set corresponding project config section for inmanta-core 9.0.
 
 # v 2.7.0 (2023-02-23)
 Changes in this release:

--- a/pytest_inmanta/core.py
+++ b/pytest_inmanta/core.py
@@ -37,7 +37,7 @@ except DistributionNotFound:
 
 # Setting a project-wide pip index is only supported for iso7+
 SUPPORTS_PROJECT_PIP_INDEX: bool = (
-    CORE_VERSION is not None and CORE_VERSION >= version.Version("10.0.0.dev")
+    CORE_VERSION is not None and CORE_VERSION >= version.Version("9.0.0.dev")
 )
 
 SUPPORTS_MODULES_V2: bool = (

--- a/pytest_inmanta/core.py
+++ b/pytest_inmanta/core.py
@@ -35,9 +35,7 @@ try:
 except DistributionNotFound:
     CORE_VERSION = None
 
-"""
---pip-index-url is only supported for iso7+
-"""
+# Setting a project-wide pip index is only supported for iso7+
 SUPPORTS_PROJECT_PIP_INDEX: bool = (
     CORE_VERSION is not None and CORE_VERSION >= version.Version("10.0.0.dev")
 )

--- a/pytest_inmanta/core.py
+++ b/pytest_inmanta/core.py
@@ -35,9 +35,11 @@ try:
 except DistributionNotFound:
     CORE_VERSION = None
 
-
+"""
+--pip-index-url is only supported for iso7+
+"""
 SUPPORTS_PROJECT_PIP_INDEX: bool = (
-    CORE_VERSION is not None and CORE_VERSION >= version.Version("9.2.0.dev")
+    CORE_VERSION is not None and CORE_VERSION >= version.Version("10.0.0.dev")
 )
 
 SUPPORTS_MODULES_V2: bool = (

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -303,6 +303,11 @@ def project_metadata(request: pytest.FixtureRequest) -> module.ProjectMetadata:
             pip=pip_config,
         )
     else:
+        if index_urls:
+            LOGGER.warning(
+                "Setting a project-wide pip index is not supported on this version of inmanta-core. "
+                "The provided index will be used as a v2 package source"
+            )
         v2_source_repos = [
             {"url": index_url, "type": "package"} for index_url in index_urls
         ]


### PR DESCRIPTION
# Description

As discussed [here](https://inmanta.slack.com/archives/CKRF0C8R3/p1688386956424409?thread_ts=1688132643.347189&cid=CKRF0C8R3):

> 1. on iso6, if you use --pip-index-url pytest-inmanta logs a warning that a project-wide pip index url is not supported on this version of inmanta-core and that it will use the index as a v2 package source instead.
> 2. on iso7+, stick with the current warning
> Wdyt? We should update the changelog note in that case.



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
