### PR TITLE
[WIP] update warning message

### DIFF
--- a/pytest_inmanta/parameters.py
+++ b/pytest_inmanta/parameters.py
@@ -96,10 +96,13 @@ inm_mod_repo = ListTestParameter(
     legacy=inm_mod_repo_legacy,
 )
 
-pip_index_urls = ListTestParameter(
-    argument="--pip-index-urls",
+pip_index_url = ListTestParameter(
+    argument="--pip-index-url",
     environment_variable="INMANTA_PIP_INDEX_URL",
-    usage="List of project-wide pip indexes",
+    usage=(
+        "Pip index to install dependencies from."
+        "Can be specified multiple times to add multiple indexes."
+    ),
     group=param_group,
     default=[],
 )

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -57,6 +57,7 @@ from inmanta.export import Exporter, ResourceDict, cfg_env
 from inmanta.protocol import json_encode
 from inmanta.resources import Resource
 from pytest_inmanta.core import SUPPORTS_PROJECT_PIP_INDEX
+
 from .test_parameter.parameter import ValueSetBy
 
 if typing.TYPE_CHECKING:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -242,7 +242,7 @@ def get_project_repos(repo_options: typing.Sequence[str]) -> typing.Sequence[obj
                         )
                     elif inm_mod_repo._value_set_using == ValueSetBy.CLI:
                         LOGGER.warning(
-                            "Setting a package source through the --module-repo <index_url> with type `package` "
+                            "Setting a package source through the --module-repo <index_url> cli option with type `package` "
                             + alternative_text,
                             pip_index_url.environment_variable,
                         )

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -231,7 +231,7 @@ def get_project_repos(repo_options: typing.Sequence[str]) -> typing.Sequence[obj
                     alternative_text: str = (
                         "is now deprecated and will raise a warning during compilation."
                         " Use the --pip-index-url <index_url> pytest option instead or set"
-                        "the %s environment variable to address these warnings. "
+                        " the %s environment variable to address these warnings. "
                     )
                     if inm_mod_repo._value_set_using == ValueSetBy.ENV_VARIABLE:
                         LOGGER.warning(

--- a/pytest_inmanta/test_parameter/list_parameter.py
+++ b/pytest_inmanta/test_parameter/list_parameter.py
@@ -87,28 +87,23 @@ class ListTestParameter(TestParameter[Sequence[str]]):
 
     def resolve(self, config: "Config") -> Sequence[str]:
         option = config.getoption(self.argument, default=self.default)
-        value_set_using: Optional[str] = None
 
-        try:
-            if option is not None and option is not self.default:
-                # A value is set, and it is not the default one
-                value_set_using = ValueSetBy.CLI
-                if isinstance(option, collections.abc.Sequence):
-                    return self.validate(option)
-                else:
-                    return self.validate([option])
+        if option is not None and option is not self.default:
+            # A value is set, and it is not the default one
+            self._value_set_using = ValueSetBy.CLI
+            if isinstance(option, collections.abc.Sequence):
+                return self.validate(option)
+            else:
+                return self.validate([option])
 
-            env_var = os.getenv(self.environment_variable)
-            if env_var is not None:
-                # A value is set
-                value_set_using = ValueSetBy.ENV_VARIABLE
-                return self.validate(env_var.split(" "))
+        env_var = os.getenv(self.environment_variable)
+        if env_var is not None:
+            # A value is set
+            self._value_set_using = ValueSetBy.ENV_VARIABLE
+            return self.validate(env_var.split(" "))
 
-            if self.default is not None:
-                value_set_using = ValueSetBy.DEFAULT_VALUE
-                return self.default
+        if self.default is not None:
+            self._value_set_using = ValueSetBy.DEFAULT_VALUE
+            return self.default
 
-            raise ParameterNotSetException(self)
-
-        finally:
-            self._value_set_using = value_set_using
+        raise ParameterNotSetException(self)

--- a/pytest_inmanta/test_parameter/parameter.py
+++ b/pytest_inmanta/test_parameter/parameter.py
@@ -165,6 +165,7 @@ class TestParameterRegistry:
             for param in parameters:
                 TestParameterRegistry.add_option(parser, group_name, param)
 
+
 class ValueSetBy(Enum):
     """
     This class is used to record how the value was provided for a test parameter.
@@ -173,7 +174,7 @@ class ValueSetBy(Enum):
     DEFAULT_VALUE: str = "DEFAULT_VALUE"
     CLI: str = "CLI"
     ENV_VARIABLE: str = "ENV_VARIABLE"
-    UNSET: str = "UNSET"
+
 
 class TestParameter(Generic[ParameterType]):
     """

--- a/pytest_inmanta/test_parameter/parameter.py
+++ b/pytest_inmanta/test_parameter/parameter.py
@@ -20,6 +20,7 @@ import os
 import uuid
 from abc import abstractmethod
 from collections import defaultdict
+from enum import Enum
 from typing import Container, Dict, Generic, List, Optional, Set, TypeVar, Union
 
 try:
@@ -164,6 +165,15 @@ class TestParameterRegistry:
             for param in parameters:
                 TestParameterRegistry.add_option(parser, group_name, param)
 
+class ValueSetBy(Enum):
+    """
+    This class is used to record how the value was provided for a test parameter.
+    """
+
+    DEFAULT_VALUE: str = "DEFAULT_VALUE"
+    CLI: str = "CLI"
+    ENV_VARIABLE: str = "ENV_VARIABLE"
+    UNSET: str = "UNSET"
 
 class TestParameter(Generic[ParameterType]):
     """
@@ -204,6 +214,8 @@ class TestParameter(Generic[ParameterType]):
         self.usage = usage
         self.default = default
         self.legacy = legacy
+        # Track how the value was set when it is being resolved:
+        self._value_set_using: Optional[str] = None
 
         TestParameterRegistry.register(key, self, group)
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -157,9 +157,9 @@ def test_transitive_v2_dependencies_legacy_warning(
 
         if SUPPORTS_PROJECT_PIP_INDEX:
             warning_msg: str = (
-                "Setting a package source through the --module-repo <index_url> with type `package` "
+                "Setting a package source through the --module-repo <index_url> cli option with type `package` "
                 "is now deprecated and will raise a warning during compilation."
                 " Use the --pip-index-url <index_url> pytest option instead or set"
-                f"the {pip_index_url.environment_variable} environment variable to address these warnings. "
+                f" the {pip_index_url.environment_variable} environment variable to address these warnings. "
             )
             assert warning_msg in caplog.text

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -26,6 +26,7 @@ import pytest_inmanta.plugin
 import utils
 from inmanta import env
 from pytest_inmanta.core import SUPPORTS_PROJECT_PIP_INDEX
+from pytest_inmanta.parameters import pip_index_url
 
 
 def test_transitive_v2_dependencies(
@@ -50,10 +51,10 @@ def test_transitive_v2_dependencies(
                     "tests/test_basics.py",
                     "--use-module-in-place",
                     # add pip index containing examples packages as module repo
-                    "--pip-index-urls",
+                    "--pip-index-url",
                     f"{examples_v2_package_index}",
                     # include configured pip index for inmanta-module-std
-                    "--pip-index-urls",
+                    "--pip-index-url",
                     f'{os.environ.get("PIP_INDEX_URL", "https://pypi.org/simple")}',
                 )
                 result.assert_outcomes(passed=1)
@@ -107,10 +108,10 @@ def test_conflicing_dependencies(
                 *(["--no-strict-deps-check"] if no_strict_deps_check else []),
                 "--use-module-in-place",
                 # add pip index containing examples packages as module repo
-                "--pip-index-urls",
+                "--pip-index-url",
                 f"{examples_v2_package_index}",
                 # include configured pip index for inmanta-module-std and lorem
-                "--pip-index-urls",
+                "--pip-index-url",
                 f'{os.environ.get("PIP_INDEX_URL", "https://pypi.org/simple")}',
             )
             result.assert_outcomes(errors=1)
@@ -157,6 +158,8 @@ def test_transitive_v2_dependencies_legacy_warning(
         if SUPPORTS_PROJECT_PIP_INDEX:
             warning_msg: str = (
                 "Setting a package source through the --module-repo <index_url> with type `package` "
-                "is now deprecated in favour of the --pip-index-urls <index_url> option.`"
+                "is now deprecated and will raise a warning during compilation."
+                " Use the --pip-index-url <index_url> pytest option instead or set"
+                f"the {pip_index_url.environment_variable} environment variable to address these warnings. "
             )
             assert warning_msg in caplog.text


### PR DESCRIPTION
# Description

- [x] Check how multiple index-urls can be specified. Is it the same as for `--module-repo` and `MODULE_REPO`? If so, we should use the singular form `--index-url` instead. The help string should also be updated to be more clear on how to use it, similar to the --module-repo help string.
- [x] Update the deprecation warning to detect whether the option or the env var was used and update the message accordingly.
- [x] Mention in the warning that this will also raise a warning during compilation and that that warning will disappear when this one is addressed.

closes https://github.com/inmanta/pytest-inmanta/issues/404

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
