### PR TITLE
Allow more options for boolean test parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 2.9.0 (?)
 Changes in this release:
+- Add support for more values (yes, 1) and (no, 0) for boolean options
 - Add `deploy_resouce_v2` endpoint
 - Add support for unmanaged resources
 - Adds a new resource entity that raises an IgnoreResourceException when buildings its id

--- a/pytest_inmanta/test_parameter/boolean_parameter.py
+++ b/pytest_inmanta/test_parameter/boolean_parameter.py
@@ -78,12 +78,13 @@ class BooleanTestParameter(TestParameter[bool]):
 
     def validate(self, raw_value: object) -> bool:
         parsed = str(raw_value).lower().strip()
-        if parsed == "false":
+        if parsed in ["false", "no", "0"]:
             return False
 
-        if parsed == "true":
+        if parsed in ["true", "yes", "1"]:
             return True
 
         raise ValueError(
-            f"Boolean env var should be set to either 'true' or 'false', got '{parsed}' instead"
+            f"Boolean env var should be set to either a truthy value ('true', 'yes' or 1) "
+            f"or a falsy value ('false', 'no' or 0), got '{parsed}' instead"
         )

--- a/pytest_inmanta/test_parameter/boolean_parameter.py
+++ b/pytest_inmanta/test_parameter/boolean_parameter.py
@@ -85,6 +85,6 @@ class BooleanTestParameter(TestParameter[bool]):
             return True
 
         raise ValueError(
-            f"Boolean env var should be set to either a truthy value ('true', 'yes' or 1) "
+            f"Boolean env var {self.environment_variable} should be set to either a truthy value ('true', 'yes' or 1) "
             f"or a falsy value ('false', 'no' or 0), got '{parsed}' instead"
         )


### PR DESCRIPTION
# Description

Allow more options for boolean test parameters

closes https://github.com/inmanta/pytest-inmanta/issues/432

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
