### PR TITLE
Fix resource unserialized when deploy_all is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 2.10.0 (?)
 Changes in this release:
 - Add support for custom `agent_map` enabling testing or remote io scenarios.
+- Make sure that the resource is serialized when `deploy_all` is used
 
 # v 2.9.0 (2023-11-29)
 Changes in this release:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ black = black pytest_inmanta tests examples
 
 .PHONY: install
 install:
-	pip install -U setuptools pip
-	pip install -U -r requirements.txt -r requirements.dev.txt
-	pip install -e .
+	pip install -U --upgrade-strategy=eager pip setuptools wheel
+	pip install -U --upgrade-strategy=eager -e . -r requirements.txt -r requirements.dev.txt
 
 .PHONY: format
 format:


### PR DESCRIPTION
# Description

When `deploy_all` was used, the resource was not serialized correctly. This led to the presence of proxy instances in the different fields of the resource, which could cause problems when interacting with an API.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
