### PR TITLE
Add stricter get_resource method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ Changes in this release:
 - Add support for custom `agent_map` enabling testing or remote io scenarios.
 - Fix resource serialization (#437)
 - Fix new agent api in inmanta.agent.executor.AgentInstance (ISO8)
-- Add `get_one_resource` method to the `project` fixture. This method is the upgraded version of `get_resource`. This new method should be used instead of the old one and any user is encouraged to migrate to the new one. Please refer to the documentation of the fixture for further information.
-- Add strict mode in `get_resource` method to  the `project` fixture (by default set to `False`). If strict mode is set to `True`, the new `get_one_resource` method will be called. 
+- Add `get_one_resource` method to the `project` fixture and `Result` object.
+- Add strict mode in `get_resource` method to  the `project` fixture and `Result` object (by default set to `False`). 
+
+## Updating
+- All uses of the `get_resource` method should be replaced with the `get_one_resource` method. It has improved type matching and raises an exception when multiple matches are present. 
 
 # v 2.9.0 (2023-11-29)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changes in this release:
 - Add support for custom `agent_map` enabling testing or remote io scenarios.
 - Fix resource serialization (#437)
 - Fix new agent api in inmanta.agent.executor.AgentInstance (ISO8)
+- Add `get_one_resource` method to the `project` fixture. This method is the upgraded version of `get_resource`. This new method should be used instead of the old one and any user is encouraged to migrate to the new one. Please refer to the documentation of the fixture for further information.
+- Add strict mode in `get_resource` method to  the `project` fixture (by default set to False). If strict mode is set to True, the new `get_one_resource` method will be called. 
 
 # v 2.9.0 (2023-11-29)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v 2.11.0 (?)
 Changes in this release:
+- Add strict mode in `get_resource` method to  the `project` fixture and `Result` object (by default set to `False`). 
+
+## Updating
+- All uses of the `get_resource` method should be replaced with the `get_one_resource` method. It has improved type matching and raises an exception when multiple matches are present.
 
 # v 2.10.0 (2024-07-05)
 Changes in this release:
@@ -7,10 +11,6 @@ Changes in this release:
 - Fix resource serialization (#437)
 - Fix new agent api in inmanta.agent.executor.AgentInstance (ISO8)
 - Add `get_one_resource` method to the `project` fixture and `Result` object.
-- Add strict mode in `get_resource` method to  the `project` fixture and `Result` object (by default set to `False`). 
-
-## Updating
-- All uses of the `get_resource` method should be replaced with the `get_one_resource` method. It has improved type matching and raises an exception when multiple matches are present. 
 
 # v 2.9.0 (2023-11-29)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes in this release:
 - Fix resource serialization (#437)
 - Fix new agent api in inmanta.agent.executor.AgentInstance (ISO8)
 - Add `get_one_resource` method to the `project` fixture. This method is the upgraded version of `get_resource`. This new method should be used instead of the old one and any user is encouraged to migrate to the new one. Please refer to the documentation of the fixture for further information.
-- Add strict mode in `get_resource` method to  the `project` fixture (by default set to False). If strict mode is set to True, the new `get_one_resource` method will be called. 
+- Add strict mode in `get_resource` method to  the `project` fixture (by default set to `False`). If strict mode is set to `True`, the new `get_one_resource` method will be called. 
 
 # v 2.9.0 (2023-11-29)
 Changes in this release:

--- a/examples/testhandler/tests/test_dryrun.py
+++ b/examples/testhandler/tests/test_dryrun.py
@@ -63,13 +63,13 @@ def test_dryrun_all(project):
     """
     )
     result = project.dryrun_all()
-    resource = result.get_resource("unittest::Resource", name="res")
+    resource = result.get_one_resource("unittest::Resource", name="res")
     assert resource.desired_value == "x"
 
-    resource = result.get_resource("unittest::Resource", name="res2")
+    resource = result.get_one_resource("unittest::Resource", name="res2")
     assert resource.desired_value == "y"
 
-    resource = result.get_resource("unittest::Resource", name="res3")
+    resource = result.get_one_resource("unittest::Resource", name="res3")
     assert resource.desired_value == "z"
 
 

--- a/examples/testhandler/tests/test_get_resource_subtle_case.py
+++ b/examples/testhandler/tests/test_get_resource_subtle_case.py
@@ -45,7 +45,9 @@ def test_ignore_resource(project: Project):
 
     # Now, with the strict mode, the types should match
     real_resource_a = project.get_resource("unittest::ResourceA", strict_mode=True)
+    real_resource_a_other_method = project.get_one_resource("unittest::ResourceA")
     assert real_resource_a.id.entity_type == "unittest::ResourceA"
+    assert real_resource_a.id.entity_type == real_resource_a_other_method.id.entity_type
 
     # Now, let's check that only one instance can exist at the same time when no filtering arguments are provided
     project.compile(

--- a/examples/testhandler/tests/test_get_resource_subtle_case.py
+++ b/examples/testhandler/tests/test_get_resource_subtle_case.py
@@ -1,0 +1,68 @@
+"""
+    Copyright 2024 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import pytest
+
+from pytest_inmanta.plugin import Project
+
+
+def test_ignore_resource(project: Project):
+    """
+    Ensure that the stricter filtering on get_resource is working as intended on a subtle scenario -> inheritance in the model
+    but relying on the same resource / handler pair. Things that need to be checked:
+        - Makes sure that the entity type of the resource is matching the one provided in the arguments
+        - Only one instance exists in the resources of the project
+    """
+    # First, let's test the old behaviour: the returned resource has an incorrect type
+    project.compile(
+        """
+    import unittest
+
+    unittest::Resource(name="res", desired_value="x")
+    unittest::ResourceA(name="fakeres", desired_value="fakex")
+    """
+    )
+
+    resource = project.get_resource("unittest::Resource")
+    wrong_resource_a = project.get_resource("unittest::ResourceA")
+    assert wrong_resource_a.id.entity_type == "unittest::Resource"
+    assert wrong_resource_a.id.entity_type == resource.id.entity_type
+
+    # Now, with the strict mode, the types should match
+    real_resource_a = project.get_resource("unittest::ResourceA", strict_mode=True)
+    assert real_resource_a.id.entity_type == "unittest::ResourceA"
+
+    # Now, let's check that only one instance can exist at the same time when no filtering arguments are provided
+    project.compile(
+        """
+    import unittest
+
+    unittest::ResourceA(name="fakeres", desired_value="fakex")
+    unittest::ResourceA(name="fakeres22", desired_value="fakex22")
+    """
+    )
+    with pytest.raises(AssertionError, match="Only one resource should be found!"):
+        project.get_resource("unittest::ResourceA", strict_mode=True)
+
+    # And let's make sure that if the resource doesn't exist, `None` is returned
+    project.compile(
+        """
+    import unittest
+    """
+    )
+    assert project.get_resource("unittest::ResourceA", strict_mode=True) is None

--- a/examples/testhandler/tests/test_get_resource_subtle_case.py
+++ b/examples/testhandler/tests/test_get_resource_subtle_case.py
@@ -21,7 +21,7 @@ import pytest
 from pytest_inmanta.plugin import Project
 
 
-def test_ignore_resource(project: Project):
+def test_subtle_get_resource(project: Project):
     """
     Ensure that the stricter filtering on get_resource is working as intended on a subtle scenario -> inheritance in the model
     but relying on the same resource / handler pair. Things that need to be checked:

--- a/examples/testhandler/tests/test_handler.py
+++ b/examples/testhandler/tests/test_handler.py
@@ -134,7 +134,7 @@ def test_close_cache(project):
     )
 
     project.deploy_resource("unittest::Resource")
-    res = project.get_resource("unittest::Resource")
+    res = project.get_one_resource("unittest::Resource")
     handler = project.get_handler(res, False)
     project.finalize_handler(handler)
     versions = handler.cache.counterforVersion.keys()

--- a/examples/testhandler/tests/test_ignore_resource.py
+++ b/examples/testhandler/tests/test_ignore_resource.py
@@ -32,6 +32,6 @@ def test_ignore_resource(project):
     """
     )
 
-    assert project.get_resource("unittest::Resource") is not None
-    assert project.get_resource("unittest::IgnoreResource") is None
-    assert project.get_resource("unittest::IgnoreResourceInIdAttr") is None
+    assert project.get_one_resource("unittest::Resource") is not None
+    assert project.get_one_resource("unittest::IgnoreResource") is None
+    assert project.get_one_resource("unittest::IgnoreResourceInIdAttr") is None

--- a/pytest_inmanta/module/init.cf
+++ b/pytest_inmanta/module/init.cf
@@ -68,3 +68,9 @@ end
 index IgnoreResourceInIdAttr(name)
 
 implement IgnoreResourceInIdAttr using std::none
+
+
+entity ResourceA extends Resource:
+end
+
+implement ResourceA using std::none

--- a/pytest_inmanta/module/init.py
+++ b/pytest_inmanta/module/init.py
@@ -30,7 +30,6 @@ class Resource(resources.PurgeableResource):
     fields = ("name", "desired_value", "skip", "fail", "fail_deploy", "wrong_diff")
 
 
-@handler.provider("unittest::ResourceA", name="test")
 @handler.provider("unittest::Resource", name="test")
 class ResourceHandler(handler.CRUDHandler):
     def read_resource(

--- a/pytest_inmanta/module/init.py
+++ b/pytest_inmanta/module/init.py
@@ -25,11 +25,13 @@ from pytest_inmanta.handler import DATA
 KEY_PREFIX = "unittest_"
 
 
+@resources.resource("unittest::ResourceA", id_attribute="name", agent="agent")
 @resources.resource("unittest::Resource", id_attribute="name", agent="agent")
 class Resource(resources.PurgeableResource):
     fields = ("name", "desired_value", "skip", "fail", "fail_deploy", "wrong_diff")
 
 
+@handler.provider("unittest::ResourceA", name="test")
 @handler.provider("unittest::Resource", name="test")
 class ResourceHandler(handler.CRUDHandler):
     def read_resource(

--- a/pytest_inmanta/module/init.py
+++ b/pytest_inmanta/module/init.py
@@ -25,7 +25,6 @@ from pytest_inmanta.handler import DATA
 KEY_PREFIX = "unittest_"
 
 
-@resources.resource("unittest::ResourceA", id_attribute="name", agent="agent")
 @resources.resource("unittest::Resource", id_attribute="name", agent="agent")
 class Resource(resources.PurgeableResource):
     fields = ("name", "desired_value", "skip", "fail", "fail_deploy", "wrong_diff")

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -800,6 +800,7 @@ def get_one_resource(
     `entity_type` matches the provided `resource_type`, unlike the `get_resource` function
     If multiple resource match, an assertion error is raised. If none match, None is returned.
 
+    :param resources: The resources to filter on
     :param resource_type: The exact type used in the model (no super types)
     """
     resources = iter(

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -747,11 +747,13 @@ def get_resources_matching(
         return True
 
     for resource in resources:
-        match_entity_type = resource.id.entity_type == resource_type
-        if not resource.is_type(resource_type) or (
-            should_filter_model_type and not match_entity_type
-        ):
-            continue
+
+        if not should_filter_model_type:
+            if not resource.is_type(resource_type):
+                continue
+        else:
+            if not resource.id.entity_type == resource_type:
+                continue
 
         if not apply_filter(resource):
             continue
@@ -821,7 +823,10 @@ def get_one_resource(
     if len(list_resources) == 0:
         list_resources.append(None)
 
-    assert len(list_resources) == 1, "Only one resource should be found!"
+    assert len(list_resources) == 1, (
+        "The filter should only match one resource, but it matches: "
+        f"[{','.join(str(resource.id) for resource in list_resources)}]"
+    )
     return list_resources[0]
 
 
@@ -889,7 +894,9 @@ class Result:
         if strict_mode:
             return self.get_one_resource(resource_type, **filter_args)
         else:
-            return get_resource(self.results.keys(), resource_type, **filter_args)
+            return get_resource(
+                self.results.keys(), resource_type, strict_mode, **filter_args
+            )
 
     def get_one_resource(
         self, resource_type: str, **filter_args: object

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -190,3 +190,13 @@ def test_cwd(testdir):
     result = testdir.runpytest("tests/test_cwd.py")
 
     result.assert_outcomes(passed=2)
+
+
+def test_get_resource(testdir):
+    """Make sure that importing functions works."""
+
+    testdir.copy_example("testhandler")
+
+    result = testdir.runpytest("tests/test_get_resource_subtle_case.py")
+
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
# Description

- Added `Project.get_one_resource` method to have a stricter filtering
- Added strict mode on `Project.get_resource` method (if set to `True`, will internally call get_one_resource)

closes https://github.com/inmanta/pytest-inmanta/issues/468

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
