### PR TITLE
Issue/no pydantic warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.2.0 (?)
 Changes in this release:
+- Make sure to use pydantic v2+ methods when they are available
 
 # v 3.1.0 (2024-10-10)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v 3.2.0 (?)
 Changes in this release:
-- Make sure to use pydantic v2+ methods when they are available
+- Make sure to use pydantic v2+ methods
 
 # v 3.1.0 (2024-10-10)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -258,7 +258,12 @@ def get_project_repos(repo_options: typing.Sequence[str]) -> typing.Sequence[obj
                             + alternative_text,
                             parameters.pip_index_url.environment_variable,
                         )
-            return json.loads(repo_info.json())
+
+            try:
+                return repo_info.model_dump(mode="json")
+            except AttributeError:
+                # Backward compatibility with pydantic v1
+                return json.loads(repo_info.json())
 
     return [parse_repo(repo) for repo in repo_options]
 
@@ -413,9 +418,13 @@ def project_factory(
             raise
 
     with open(os.path.join(project_dir, "project.yml"), "w+") as fd:
-        # pydantic.BaseModel.dict() doesn't produce data that can be serialized
-        # so we first serialize it as json, then load it and dump it as yaml.
-        yaml.safe_dump(json.loads(project_metadata.json()), fd)
+        try:
+            yaml.safe_dump(project_metadata.model_dump(mode="json"), fd)
+        except AttributeError:
+            # Backward compatibility with pydantic v1
+            # pydantic.BaseModel.dict() doesn't produce data that can be serialized
+            # so we first serialize it as json, then load it and dump it as yaml.
+            yaml.safe_dump(json.loads(project_metadata.json()), fd)
 
     ensure_current_module_install(
         os.path.join(project_dir, "libs"),

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -259,11 +259,7 @@ def get_project_repos(repo_options: typing.Sequence[str]) -> typing.Sequence[obj
                             parameters.pip_index_url.environment_variable,
                         )
 
-            try:
-                return repo_info.model_dump(mode="json")
-            except AttributeError:
-                # Backward compatibility with pydantic v1
-                return json.loads(repo_info.json())
+            return repo_info.model_dump(mode="json")
 
     return [parse_repo(repo) for repo in repo_options]
 
@@ -418,13 +414,7 @@ def project_factory(
             raise
 
     with open(os.path.join(project_dir, "project.yml"), "w+") as fd:
-        try:
-            yaml.safe_dump(project_metadata.model_dump(mode="json"), fd)
-        except AttributeError:
-            # Backward compatibility with pydantic v1
-            # pydantic.BaseModel.dict() doesn't produce data that can be serialized
-            # so we first serialize it as json, then load it and dump it as yaml.
-            yaml.safe_dump(json.loads(project_metadata.json()), fd)
+        yaml.safe_dump(project_metadata.model_dump(mode="json"), fd)
 
     ensure_current_module_install(
         os.path.join(project_dir, "libs"),


### PR DESCRIPTION
# Description

Some fixtures were still using pydantic v1 by default, which raises warnings in every ci.  This addresses it.  I don't know if we still support pydantic v1 for any version of the product, I kept it here by default, but maybe we can drop it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
