### PR TITLE
Remove reference to deprecated module install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes in this release:
 - Format code using black 25.1.0
 - Make sure to use pydantic v2+ methods
 - Fix configuration of temporary state dir with the project fixture
+- Remove reference to deprecated module install command
 
 # v 3.1.0 (2024-10-10)
 Changes in this release:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install pytest-inmanta
 
 If you want to use `pytest-inmanta` to test a v2 module, make sure to install the module:
 ```bash
-inmanta module install -e .
+pip install -e .
 ```
 
 ## Usage

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -475,12 +475,12 @@ def ensure_current_module_install(v1_modules_dir: str, in_place: bool = False) -
         if installed is None:
             raise Exception(
                 "The module being tested is not installed in the current Python environment. Please install it with"
-                " `inmanta module install -e .` before running the tests."
+                " `pip install -e .` before running the tests."
             )
         if not installed.is_editable():
             LOGGER.warning(
                 "The module being tested is not installed in editable mode. As a result the tests will not pick up any changes"
-                " to the local source files. To install it in editable mode, run `inmanta module install -e .`."
+                " to the local source files. To install it in editable mode, run `pip install -e .`."
             )
 
 

--- a/tests/test_basic_example_v2.py
+++ b/tests/test_basic_example_v2.py
@@ -111,7 +111,7 @@ def test_basic_example_no_install(testdir: pytest.Testdir) -> None:
     result.stdout.re_match_lines(
         [
             r".*Exception: The module being tested is not installed in the current Python environment\."
-            r" Please install it with `inmanta module install -e \.` before running the tests\..*"
+            r" Please install it with `pip install -e \.` before running the tests\..*"
         ]
     )
 

--- a/tests/test_basic_example_v2.py
+++ b/tests/test_basic_example_v2.py
@@ -94,7 +94,7 @@ def test_basic_example(
             assert (
                 "The module being tested is not installed in editable mode."
                 " As a result the tests will not pick up any changes to the local source files."
-                " To install it in editable mode, run `inmanta module install -e .`."
+                " To install it in editable mode, run `pip install -e .`."
                 in caplog.messages
             )
 


### PR DESCRIPTION
# Description

Switch deprecated `inmanta module install -e .` to `pip install -e .` in error reporting.

Do we need a changelog entry for this?

closes #518 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
