### PR TITLE
Issue/clear logs before compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.3.0 (?)
 Changes in this release:
+- Fix memory leak caused by pytest LogCaptureHandler.  Address it by clearing the old in-memory logs before each compile.
 
 # v 3.2.0 (2025-04-09)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1435,7 +1435,7 @@ license: Test License
         # Reset logging before compile to avoid leaking objects from previous compiles
         for handler in logging.getLogger().handlers:
             if isinstance(handler, _pytest.logging.LogCaptureHandler):
-                handler.clear()
+                handler.records.clear()
 
         # logging model with line numbers
         def enumerate_model(model: str):

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1433,9 +1433,9 @@ license: Test License
         :param no_dedent: Don't remove additional indentation in the model
         """
         # Reset logging before compile to avoid leaking objects from previous compiles
-        for handler in logging.getLogger().handlers:
-            if isinstance(handler, _pytest.logging.LogCaptureHandler):
-                handler.records.clear()
+        for log_handler in logging.getLogger().handlers:
+            if isinstance(log_handler, _pytest.logging.LogCaptureHandler):
+                log_handler.records.clear()
 
         # logging model with line numbers
         def enumerate_model(model: str):

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1440,7 +1440,7 @@ license: Test License
             for log_handler in logging.getLogger().handlers:
                 if isinstance(log_handler, _pytest.logging.LogCaptureHandler):
                     log_handler.records.clear()
-        except ImportError:
+        except (ImportError, AttributeError):
             # Nothing to do, hopefully the leak induced by the logs will not trigger to
             # many issues until pytest-inmanta is updated
             pass

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -43,6 +43,7 @@ import pytest
 import yaml
 from tornado import ioloop
 
+import _pytest.logging  # Unsafe import, paired with explicit version constraint on pytest
 import inmanta.ast
 from inmanta import compiler, config, const, module, plugins, protocol
 from inmanta.agent import cache
@@ -1431,6 +1432,10 @@ license: Test License
         :param export: Whether the model should be exported after the compile
         :param no_dedent: Don't remove additional indentation in the model
         """
+        # Reset logging before compile to avoid leaking objects from previous compiles
+        for handler in logging.getLogger().handlers:
+            if isinstance(handler, _pytest.logging.LogCaptureHandler):
+                handler.clear()
 
         # logging model with line numbers
         def enumerate_model(model: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ inmanta-dev-dependencies==1.76.0; python_version <= '3.6'
 inmanta-dev-dependencies==2.158.0; python_version > '3.6'
 inmanta-core
 pyyaml==6.0.2
-pytest==8.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ inmanta-dev-dependencies==1.76.0; python_version <= '3.6'
 inmanta-dev-dependencies==2.158.0; python_version > '3.6'
 inmanta-core
 pyyaml==6.0.2
+pytest==8.3.5

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        # Constraint the version of pytest because we have some imports which are
-        # not part of the stable api.  i.e. import _pytest.logging
-        # The version constraint should be increased by dependabot
-        "pytest<8.4",
+        "pytest",
         "inmanta-core",
         "pydantic",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,15 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     zip_safe=False,
-    install_requires=["pytest", "inmanta-core", "pydantic", "pyyaml"],
+    install_requires=[
+        # Constraint the version of pytest because we have some imports which are
+        # not part of the stable api.  i.e. import _pytest.logging
+        # The version constraint should be increased by dependabot
+        "pytest<8.4",
+        "inmanta-core",
+        "pydantic",
+        "pyyaml",
+    ],
     entry_points={
         "pytest11": ["inmanta = pytest_inmanta.plugin"],
     },

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -16,7 +16,22 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import logging
+
 # Note: These tests only function when the pytest output is not modified by plugins such as pytest-sugar!
+
+
+def test_pytest_logging_import():
+    """
+    This test case asserts that some component of pytest unstable/unofficial api don't
+    change in a way that would impact us.  If this test fails, we need to update the
+    log clearing logic at the start of the `Project.compile` method, to avoid significant
+    memory leaks in test suites running many compiles or complex models.
+    """
+    import _pytest.logging
+
+    assert hasattr(_pytest.logging, "LogCaptureHandler")
+    assert issubclass(_pytest.logging.LogCaptureHandler, logging.StreamHandler)
 
 
 def test_basic_example(testdir):

--- a/tests/test_basic_example_v2.py
+++ b/tests/test_basic_example_v2.py
@@ -95,7 +95,7 @@ def test_basic_example(
                 "The module being tested is not installed in editable mode."
                 " As a result the tests will not pick up any changes to the local source files."
                 " To install it in editable mode, run `pip install -e .`."
-                in caplog.messages
+                in caplog.text
             )
 
 


### PR DESCRIPTION
# Description

- Clear pytest's in-memory logs before each compile to avoid heavy memory leaks

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
