### PR TITLE
Fix incompatibility inmanta-core: push environment settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Add support for skip in reference
 - Fix memory leak caused by pytest LogCaptureHandler.  Address it by clearing the old in-memory logs before each compile.
+- Fix incompatibility with versions of inmanta-core that have support to push environment settings to the server.
 
 # v 3.2.0 (2025-04-09)
 Changes in this release:

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1490,7 +1490,10 @@ license: Test License
             # to push environment_settings to the server. Only push environment settings
             # on export.
             version, resources = exporter.run(
-                types, scopes, no_commit=not export, export_env_var_settings=export_env_var_settings
+                types,
+                scopes,
+                no_commit=not export,
+                export_env_var_settings=export_env_var_settings,
             )
         else:
             version, resources = exporter.run(types, scopes, no_commit=not export)

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1433,7 +1433,13 @@ license: Test License
             # Save the uri for this agent name
             self.agent_map[resource.agentname] = resource.uri
 
-    def compile(self, main: str, export: bool = False, no_dedent: bool = True) -> None:
+    def compile(
+        self,
+        main: str,
+        export: bool = False,
+        no_dedent: bool = True,
+        export_env_var_settings: bool = False,
+    ) -> None:
         """
         Compile the configuration model in main. This method will load all required modules.
 
@@ -1484,7 +1490,7 @@ license: Test License
             # to push environment_settings to the server. Only push environment settings
             # on export.
             version, resources = exporter.run(
-                types, scopes, no_commit=not export, export_env_var_settings=export
+                types, scopes, no_commit=not export, export_env_var_settings=export_env_var_settings
             )
         else:
             version, resources = exporter.run(types, scopes, no_commit=not export)

--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -1479,7 +1479,15 @@ license: Test License
 
         exporter = Exporter()
 
-        version, resources = exporter.run(types, scopes, no_commit=not export)
+        if "environment_settings" in module.ProjectMetadata.model_fields:
+            # We are running against a new version of inmanta-core that has support
+            # to push environment_settings to the server. Only push environment settings
+            # on export.
+            version, resources = exporter.run(
+                types, scopes, no_commit=not export, export_env_var_settings=export
+            )
+        else:
+            version, resources = exporter.run(types, scopes, no_commit=not export)
 
         for key, blob in exporter._file_store.items():
             self.add_blob(key, blob)


### PR DESCRIPTION
# Description

Fix incompatibility with versions of inmanta-core that have support to push environment settings to the server.

Related to https://github.com/inmanta/inmanta-core/pull/9355

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
