### PR TITLE
test unloading

### DIFF
--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -627,6 +627,7 @@ class ProjectLoader:
     def _unregister_old(cls, project: module.Project):
         """
         Resources, handlers and references are not unloaded or re-registered
+        by default in-between runs.
 
         When not importing a module on a second run we need to de-register them
         to prevent the exporter from failing when it tries to export them.


### PR DESCRIPTION
# Description
1. this fixes the problem
2. testcase is simple, but requires `pytest-inmanta-lsm`. Where do I put it?  I'm in favor of putting it there. 

```
def test_reload(project, remote_orchestrator):
    project.compile("import lsm", export=True)
    project.compile('std::print("test")', export=True)
```

3. should I move this into core, if so, which versions? 

closes #526 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
