### PR TITLE
Call compiler reset method from inmanta-core

### DIFF
--- a/pytest_inmanta/plugin.py
+++ b/pytest_inmanta/plugin.py
@@ -581,6 +581,10 @@ class ProjectLoader:
         # deregister plugins
         plugins.PluginMeta.clear()
 
+        # Reset the compiler state
+        if hasattr(compiler, "reset"):
+            compiler.reset()
+
         project.load()
 
         # complete the set of registered plugins from the previously registered ones
@@ -1584,6 +1588,8 @@ license: Test License
             initpy=get_module_data("init.py"),
         )
         ProjectLoader.clear_dynamic_modules()
+        if hasattr(compiler, "reset"):
+            compiler.reset()
         os.chdir(CURDIR)
         sys.executable = SYS_EXECUTABLE
 


### PR DESCRIPTION
# Description

This PR resets the compiler state between two consecutive compiles by calling into the compiler reset method implemented in inmanta-core.

closes https://github.com/inmanta/pytest-inmanta/issues/526

# Self Check:

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~